### PR TITLE
mcp-probe v0.1 launch content — disambiguation matrix, leaderboard, authoritative tokens

### DIFF
--- a/.mcp-probe.toml.example
+++ b/.mcp-probe.toml.example
@@ -15,6 +15,8 @@ allow_writes = false      # never invoke destructive tools unless true (NFR-9)
 # --- cost ---
 tokenizer = "o200k_base"  # offline tiktoken encoding for deterministic counts
 # price_points = ["premium:3.0", "cheap:0.15"]   # $ per 1M input tokens
+# token_model = "anthropic:claude-sonnet-5"   # opt-in authoritative Claude count; needs
+#                                             # ANTHROPIC_API_KEY, else falls back to estimate
 
 # --- legibility ([llm], opt-in) ---
 # model = "ollama:qwen2.5-3b"   # pinned local model is the canonical scorer (ADR-004)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,17 @@
 
 > Lint, contract-test, benchmark, and load-test your MCP server before you ship it. The `pytest` + `lighthouse` for the servers agents depend on.
 
-<!-- TODO: demo GIF — the graded report + the legibility misuse-matrix -->
-<p align="center"><em>▶ demo GIF coming — the graded MCP Quality Score report</em></p>
+<!-- Record the GIF from scripts/demo.sh: asciinema rec demo.cast -c "bash scripts/demo.sh" && agg demo.cast demo.gif -->
 
-> **Status:** 🚧 v0.1 in progress — the wedge project (ships first of the tools).
+**▶ See the [live demo](./docs/demo.md)** — the token tax and the disambiguation matrix, captured from real runs. Or the [leaderboard](./docs/leaderboard.md): mcp-probe run against real public MCP servers.
+
+```console
+$ mcp-probe run "python my_server.py" --legibility
+Legibility  F   archive_record⇄delete_record confused 100% of the time   ← caught before you ship
+Cost        D   8,792 toolset tokens — paid on every turn, before anything works
+```
+
+> **Status:** v0.1 implemented — all five families, CLI, CI, badge. See the [roadmap](./ROADMAP.md).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,11 +1,14 @@
 # mcp-probe — Roadmap
 
-> **Status (2026-07-17):** v0.1 implemented — all five families, CLI (`run`/`static`/
-> `snapshot`/`badge`), JSON + `--fail-under` + `--no-regressions` gates, badge, snapshot
-> regression, `--deep-security` adapters, dogfooding CI. 89 tests green (fast path
-> deterministic & <1s on 30 tools). Real LLM providers wired but exercised only via the
-> opt-in `live_llm` suite. See `docs/DECISIONS.md` for deviations. Remaining before launch:
-> HTTP/SSE live integration tests, the demo GIF, and the 20-server leaderboard.
+> **Status (2026-07-18):** v0.1 feature-complete. All five families, CLI
+> (`run`/`static`/`snapshot`/`badge`), JSON + `--fail-under` + `--no-regressions` gates,
+> badge, snapshot regression, `--deep-security` adapters, opt-in authoritative Anthropic
+> token counts, the disambiguation-matrix renderer, and dogfooding CI. **97 tests green**
+> (+ opt-in `live_llm`, verified against Ollama) over stdio + Streamable-HTTP + SSE.
+> [Leaderboard](../docs/leaderboard.md) run against 7 real public MCP servers (6×A, 1×D);
+> [demo](../docs/demo.md) captured. See `docs/DECISIONS.md` for deviations.
+> Remaining: record the demo GIF (script in `scripts/demo.sh`; needs asciinema), expand the
+> leaderboard, and the launch essay.
 
 ## v0.1 (launch)
 - All five check families (Contract, Legibility, Cost, Performance, Security-lite)

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -56,6 +56,15 @@ requirements; a counter that silently needs the network would violate both. The 
 is lower-fidelity but reproducible; the *relative* per-tool attribution the score depends
 on is preserved.
 
+**Authoritative opt-in (implemented):** `--token-model anthropic:<model>` uses the
+Anthropic `count_tokens` endpoint (which accepts a `tools` array) for the exact,
+billing-grade Claude count of the headline total — the only accurate Claude count, since
+no offline Claude tokenizer exists. Per-tool weights stay on the fast offline leave-one-out
+and are rescaled to the authoritative total (one API call, no rate-limit risk). It is
+strictly opt-in and falls back silently to the labeled offline estimate when
+`ANTHROPIC_API_KEY` is absent, the SDK isn't installed, or the call fails — so the fast
+path stays keyless and CI never depends on it.
+
 ## D4 — Legibility runs offline lints without a model (partial, not blank)
 
 **Spec:** Legibility is `[llm]`, opt-in, off the CI-critical path (ADR-002).

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,72 @@
+# mcp-probe demo
+
+The two things no other tool shows in a CI gate: the **toolset token number** and the
+**disambiguation matrix**. Captured from real runs against the repo's fixture servers.
+To record a GIF: `asciinema rec demo.cast -c "bash scripts/demo.sh" && agg demo.cast demo.gif`.
+
+## 1. The token tax — what every agent pays just to *see* your tools
+
+```console
+$ mcp-probe run "python tests/servers/bloated_server.py" --fail-under B
+╭─────────────────────────────────╮
+│ MCP Quality Score  81   Grade B │
+╰─────────────────────────────────╯
+┏━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Family      ┃  Grade  ┃   Score ┃   Weight ┃ Headline                                ┃
+┡━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Cost        │    D    │      69 │      60% │ 8792 toolset tokens; $0.0264/task       │
+│ Contract    │    A    │     100 │      40% │ 30 tools conform                        │
+└─────────────┴─────────┴─────────┴──────────┴─────────────────────────────────────────┘
+```
+
+30 tools that all *work* — but they cost **8,792 tokens** on every single turn, before the
+agent does anything. That number is invisible until something like this prints it.
+
+## 2. The disambiguation matrix — which tools do agents confuse?
+
+```console
+$ mcp-probe run "python tests/servers/confusable_server.py" \
+    --legibility --model ollama:mistral-small:latest --allow-writes
+╭─────────────────────────────────╮
+│ MCP Quality Score  67   Grade D │
+╰─────────────────────────────────╯
+⚠ hard-gate: 'legibility' capped the overall grade at C
+┏━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Family     ┃ Grade ┃ Score ┃ Weight ┃ Headline                                       ┃
+┡━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Cost       │   A   │   100 │    40% │ 122 toolset tokens; $0.0004/task               │
+│ Legibility │   F   │     0 │    33% │ 50% right-tool selection;                      │
+│            │       │       │        │ archive_record⇄delete_record 100%              │
+│ Contract   │   A   │   100 │    27% │ 2 tools conform                                │
+└────────────┴───────┴───────┴────────┴────────────────────────────────────────────────┘
+
+Top findings
+  [high] legibility/L2-confusion  agents chose 'delete_record' when 'archive_record'
+                                  was correct 100% of the time
+      ↳ disambiguate the two descriptions (see proposed rewrite)
+  [low]  legibility/L5-rewrite  'archive_record' is hard to select; a clearer description
+      ↳ proposed: Remove a record by its ID using `delete_record`. Use `archive_record`
+        to move a record to the archive without deleting it.
+
+Disambiguation matrix  (row = correct tool · cell = % of times chosen)
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┓
+┃ correct ↓ / chose → ┃ delete ┃ archiv ┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━┩
+│ delete_record       │   100% │      · │
+│ archive_record      │   100% │     0% │
+└─────────────────────┴────────┴────────┘
+```
+
+Two tools with the description *"Remove a record by id."* A real model (`mistral-small`
+via Ollama) picked **`delete_record` 100% of the time — even when `archive_record` was the
+right call.** That's a data-loss bug waiting to happen, caught before shipping — and
+mcp-probe even proposes the rewrite that fixes it.
+
+## 3. In CI
+
+```yaml
+- run: pip install mcp-probe
+- run: mcp-probe run "python my_server.py" --fail-under B --no-regressions
+```
+
+See the [leaderboard](./leaderboard.md) for these checks run against real public MCP servers.

--- a/docs/leaderboard.json
+++ b/docs/leaderboard.json
@@ -1,0 +1,107 @@
+[
+  {
+    "server": "server-everything",
+    "command": "npx -y @modelcontextprotocol/server-everything",
+    "grade": "A",
+    "score": 94.87179487179488,
+    "tools": 13,
+    "toolset_tokens": 1292,
+    "top_confusion": null,
+    "families": {
+      "contract": "B",
+      "cost": "A",
+      "security": "A"
+    },
+    "error": ""
+  },
+  {
+    "server": "server-memory",
+    "command": "npx -y @modelcontextprotocol/server-memory",
+    "grade": "A",
+    "score": 100.0,
+    "tools": 9,
+    "toolset_tokens": 1112,
+    "top_confusion": null,
+    "families": {
+      "contract": "A",
+      "cost": "A",
+      "security": "A"
+    },
+    "error": ""
+  },
+  {
+    "server": "server-sequential-thinking",
+    "command": "npx -y @modelcontextprotocol/server-sequential-thinking",
+    "grade": "D",
+    "score": 66.66666666666667,
+    "tools": 1,
+    "toolset_tokens": 918,
+    "top_confusion": null,
+    "families": {
+      "contract": "F",
+      "cost": "A",
+      "security": "A"
+    },
+    "error": ""
+  },
+  {
+    "server": "server-filesystem",
+    "command": "npx -y @modelcontextprotocol/server-filesystem /tmp",
+    "grade": "A",
+    "score": 98.66666666666667,
+    "tools": 14,
+    "toolset_tokens": 1901,
+    "top_confusion": null,
+    "families": {
+      "contract": "A",
+      "cost": "A",
+      "security": "A"
+    },
+    "error": ""
+  },
+  {
+    "server": "mcp-server-time",
+    "command": "uvx mcp-server-time",
+    "grade": "A",
+    "score": 100.0,
+    "tools": 2,
+    "toolset_tokens": 275,
+    "top_confusion": null,
+    "families": {
+      "contract": "A",
+      "cost": "A",
+      "security": "A"
+    },
+    "error": ""
+  },
+  {
+    "server": "mcp-server-fetch",
+    "command": "uvx mcp-server-fetch",
+    "grade": "A",
+    "score": 100.0,
+    "tools": 1,
+    "toolset_tokens": 290,
+    "top_confusion": null,
+    "families": {
+      "contract": "A",
+      "cost": "A",
+      "security": "A"
+    },
+    "error": ""
+  },
+  {
+    "server": "mcp-server-git",
+    "command": "uvx mcp-server-git",
+    "grade": "A",
+    "score": 100.0,
+    "tools": 12,
+    "toolset_tokens": 1407,
+    "top_confusion": null,
+    "families": {
+      "contract": "A",
+      "cost": "A",
+      "security": "A"
+    },
+    "error": ""
+  }
+]

--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -1,0 +1,22 @@
+# MCP Quality Leaderboard
+
+> Scored with **mcp-probe 0.1.0** (rubric `2026.07.1`). Fast path (Contract + Cost) + Security-lite. Keyless, offline-deterministic. Servers requiring API keys are listed but not scored.
+
+| # | Server | Grade | Score | Tools | Toolset tokens | Top confusion | Notes |
+|---|--------|-------|-------|-------|----------------|---------------|-------|
+| 1 | `server-memory` | **A** | 100 | 9 | 1,112 | — |  |
+| 2 | `mcp-server-time` | **A** | 100 | 2 | 275 | — |  |
+| 3 | `mcp-server-fetch` | **A** | 100 | 1 | 290 | — |  |
+| 4 | `mcp-server-git` | **A** | 100 | 12 | 1,407 | — |  |
+| 5 | `server-filesystem` | **A** | 99 | 14 | 1,901 | — |  |
+| 6 | `server-everything` | **A** | 95 | 13 | 1,292 | — |  |
+| 7 | `server-sequential-thinking` | **D** | 67 | 1 | 918 | — | hard-gate: contract |
+
+### Not scored (require credentials)
+`server-github`, `server-slack`, `server-brave-search`, `server-google-maps`, `server-postgres`
+
+### Reading the grades
+- A **contract hard-gate** usually means the determinism probe (REQ-C5) called a tool twice with identical args and got different results. For a *stateful* tool (e.g. sequential-thinking accumulates state) that's by-design — the fix is to declare the output volatile, not to change behaviour. mcp-probe flags undeclared nondeterminism; whether it's a defect is the author's call.
+- **Toolset tokens** is the context tax every agent pays each turn just to see the tools — the single most actionable number here.
+
+_Reproduce: `python scripts/leaderboard.py`. Grades reflect the servers' published tool surface at scan time; a lower grade is an invitation to a PR, not a verdict._

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,8 @@ ignore = ["SIM102", "SIM108"]
 "src/mcp_probe/report/render.py" = ["E501"]
 # Tests favour readable inline fixtures over strict wrapping.
 "tests/**" = ["E501"]
+# One-shot utility scripts: blocking file I/O and long table strings are fine.
+"scripts/**" = ["E501", "ASYNC240"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# mcp-probe demo — the two things no other tool shows in a CI gate:
+#   (1) the toolset token number, (2) the disambiguation matrix.
+#
+# Record a GIF with:  asciinema rec demo.cast -c "bash scripts/demo.sh" && agg demo.cast demo.gif
+# Requires: mcp-probe installed; PY = a python with the MCP SDK; Ollama for the matrix step.
+set -euo pipefail
+
+PY="${PY:-python}"
+S="tests/servers"
+pause() { sleep "${1:-2}"; }
+say() { printf '\n\033[1;38;5;52m$ %s\033[0m\n' "$*"; }
+
+say "mcp-probe run \"$PY $S/good_server.py\""
+mcp-probe run "$PY $S/good_server.py" 2>/dev/null; pause 3
+
+say "# a bloated toolset — watch the token tax every agent pays"
+say "mcp-probe run \"$PY $S/bloated_server.py\" --fail-under B"
+mcp-probe run "$PY $S/bloated_server.py" --fail-under B 2>/dev/null || echo "exit $? — gate failed (as it should)"; pause 4
+
+say "# the headline: which tools do agents confuse? (needs a local model)"
+say "mcp-probe run \"$PY $S/confusable_server.py\" --legibility --model ollama:mistral-small:latest --allow-writes"
+if curl -s --max-time 2 http://localhost:11434/api/tags >/dev/null 2>&1; then
+  mcp-probe run "$PY $S/confusable_server.py" --legibility \
+    --model "${MCP_PROBE_LIVE_MODEL:-ollama:mistral-small:latest}" --allow-writes 2>/dev/null
+else
+  echo "(skipped — Ollama not running on :11434)"
+fi
+pause 4
+
+say "# CI gate + badge, in one line"
+say "mcp-probe run \"$PY $S/good_server.py\" --fail-under B && mcp-probe badge --from <report>.json"
+echo "✓ mcp-probe: A"

--- a/scripts/leaderboard.py
+++ b/scripts/leaderboard.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python
+"""Score a set of public MCP servers and emit a ranked leaderboard (launch content).
+
+This is a *use* of v0.1, not new engine code: it drives ``run_probe`` over a curated list
+of credential-free public reference servers (run via npx/uvx), then writes a ranked
+Markdown table + JSON. Servers that need API keys are listed but not scored (honest — we
+don't fake a grade we couldn't measure). Failures (download timeout, non-conformant) are
+recorded, never crash the batch.
+
+Usage:
+    python scripts/leaderboard.py                 # fast path + security-lite (keyless)
+    python scripts/leaderboard.py --legibility    # add legibility via local Ollama
+    python scripts/leaderboard.py --only everything,memory   # subset
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from mcp_probe import RUBRIC_VERSION, __version__  # noqa: E402
+from mcp_probe.config import ProbeConfig  # noqa: E402
+from mcp_probe.pipeline import run_probe  # noqa: E402
+
+
+@dataclass
+class ServerSpec:
+    key: str
+    label: str
+    command: str
+    note: str = ""
+
+
+# Credential-free public reference servers (github.com/modelcontextprotocol/servers + PyPI).
+SERVERS: list[ServerSpec] = [
+    ServerSpec("everything", "server-everything", "npx -y @modelcontextprotocol/server-everything"),
+    ServerSpec("memory", "server-memory", "npx -y @modelcontextprotocol/server-memory"),
+    ServerSpec("sequentialthinking", "server-sequential-thinking",
+               "npx -y @modelcontextprotocol/server-sequential-thinking"),
+    ServerSpec("filesystem", "server-filesystem", "npx -y @modelcontextprotocol/server-filesystem /tmp"),
+    ServerSpec("time", "mcp-server-time", "uvx mcp-server-time"),
+    ServerSpec("fetch", "mcp-server-fetch", "uvx mcp-server-fetch"),
+    ServerSpec("git", "mcp-server-git", "uvx mcp-server-git"),
+]
+
+# Popular servers that gate on credentials — listed for context, not scored (honest).
+CREDENTIAL_GATED = ["server-github", "server-slack", "server-brave-search", "server-google-maps", "server-postgres"]
+
+
+@dataclass
+class Row:
+    spec: ServerSpec
+    grade: str = "—"
+    score: float | None = None
+    tools: int = 0
+    toolset_tokens: int | None = None
+    top_confusion: list | None = None
+    hard_gate: str | None = None
+    error: str = ""
+    elapsed_s: float = 0.0
+    families: dict = field(default_factory=dict)
+
+
+async def probe_one(spec: ServerSpec, *, families: tuple[str, ...], model: str | None) -> Row:
+    row = Row(spec=spec)
+    start = time.monotonic()
+    cfg = ProbeConfig(
+        target=spec.command,
+        transport="stdio",
+        families=families,
+        model=model,
+        stdio_timeout=150.0,  # npx/uvx first-run downloads can be slow
+        concurrency=8,
+    )
+    try:
+        outcome = await asyncio.wait_for(run_probe(cfg), timeout=240)
+        r = outcome.report
+        row.grade = r.overall_grade
+        row.score = r.overall_score
+        row.hard_gate = r.hard_gate
+        cost = r.families.get("cost")
+        if cost:
+            row.toolset_tokens = cost.metrics.get("toolset_tokens")
+        row.tools = len(r.surface.tools)
+        leg = r.families.get("legibility")
+        if leg:
+            row.top_confusion = leg.metrics.get("top_confusion")
+        row.families = {n: (f.grade if f.measured else "n/m") for n, f in r.families.items()}
+    except TimeoutError:
+        row.error = "timeout"
+    except Exception as exc:  # unreachable / non-conformant / download failure
+        row.error = f"{type(exc).__name__}: {exc}"[:120]
+    row.elapsed_s = round(time.monotonic() - start, 1)
+    return row
+
+
+def _score_key(row: Row) -> float:
+    return row.score if row.score is not None else -1.0
+
+
+def render_markdown(rows: list[Row], model: str | None) -> str:
+    ranked = sorted(rows, key=_score_key, reverse=True)
+    lines = [
+        "# MCP Quality Leaderboard",
+        "",
+        f"> Scored with **mcp-probe {__version__}** (rubric `{RUBRIC_VERSION}`). "
+        "Fast path (Contract + Cost) + Security-lite"
+        + (", Legibility via local Ollama" if model else "")
+        + ". Keyless, offline-deterministic. Servers requiring API keys are listed but not scored.",
+        "",
+        "| # | Server | Grade | Score | Tools | Toolset tokens | Top confusion | Notes |",
+        "|---|--------|-------|-------|-------|----------------|---------------|-------|",
+    ]
+    for i, row in enumerate(ranked, 1):
+        if row.error:
+            lines.append(
+                f"| — | `{row.spec.label}` | — | — | — | — | — | ⚠ {row.error} ({row.elapsed_s}s) |"
+            )
+            continue
+        tok = f"{row.toolset_tokens:,}" if row.toolset_tokens is not None else "—"
+        conf = "—"
+        if row.top_confusion:
+            a, b, r = row.top_confusion
+            conf = f"`{a}`⇄`{b}` {r:.0%}"
+        note = f"hard-gate: {row.hard_gate}" if row.hard_gate else ""
+        lines.append(
+            f"| {i} | `{row.spec.label}` | **{row.grade}** | {row.score:.0f} | {row.tools} "
+            f"| {tok} | {conf} | {note} |"
+        )
+    lines += [
+        "",
+        "### Not scored (require credentials)",
+        ", ".join(f"`{s}`" for s in CREDENTIAL_GATED),
+        "",
+        "### Reading the grades",
+        "- A **contract hard-gate** usually means the determinism probe (REQ-C5) called a "
+        "tool twice with identical args and got different results. For a *stateful* tool "
+        "(e.g. sequential-thinking accumulates state) that's by-design — the fix is to "
+        "declare the output volatile, not to change behaviour. mcp-probe flags undeclared "
+        "nondeterminism; whether it's a defect is the author's call.",
+        "- **Toolset tokens** is the context tax every agent pays each turn just to see the "
+        "tools — the single most actionable number here.",
+        "",
+        "_Reproduce: `python scripts/leaderboard.py`. Grades reflect the servers' published "
+        "tool surface at scan time; a lower grade is an invitation to a PR, not a verdict._",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--legibility", action="store_true", help="add legibility via Ollama")
+    parser.add_argument("--model", default="ollama:mistral-small:latest")
+    parser.add_argument("--only", default="", help="comma-separated server keys to run")
+    parser.add_argument("--out", default="docs/leaderboard.md")
+    args = parser.parse_args()
+
+    families = ("contract", "cost", "security")
+    model = None
+    if args.legibility:
+        families = ("contract", "cost", "security", "legibility")
+        model = args.model
+
+    specs = SERVERS
+    if args.only:
+        wanted = set(args.only.split(","))
+        specs = [s for s in SERVERS if s.key in wanted]
+
+    rows: list[Row] = []
+    for spec in specs:  # sequential: parallel npx downloads thrash disk/network
+        print(f"probing {spec.label} …", file=sys.stderr)
+        row = await probe_one(spec, families=families, model=model)
+        if row.error:
+            status = row.error
+        elif row.score is not None:
+            status = f"{row.grade} ({row.score:.0f})"
+        else:
+            status = "?"
+        print(f"  → {status}  [{row.elapsed_s}s]", file=sys.stderr)
+        rows.append(row)
+
+    md = render_markdown(rows, model)
+    Path(args.out).write_text(md, encoding="utf-8")
+    Path(args.out).with_suffix(".json").write_text(
+        json.dumps(
+            [
+                {
+                    "server": r.spec.label, "command": r.spec.command, "grade": r.grade,
+                    "score": r.score, "tools": r.tools, "toolset_tokens": r.toolset_tokens,
+                    "top_confusion": r.top_confusion, "families": r.families, "error": r.error,
+                }
+                for r in rows
+            ],
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    print(f"\nwrote {args.out}", file=sys.stderr)
+    print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/mcp_probe/cli.py
+++ b/src/mcp_probe/cli.py
@@ -74,6 +74,12 @@ def _add_family_flags(sp: argparse.ArgumentParser) -> None:
     sp.add_argument("--security", action="store_true", help="add the Security-lite family")
     sp.add_argument("--deep-security", action="store_true", help="shell out to mcp-scan / Cisco")
     sp.add_argument("--model", default=None, help="legibility model, e.g. 'ollama:qwen2.5-3b'")
+    sp.add_argument(
+        "--token-model",
+        default=None,
+        help="authoritative token count via a provider, e.g. 'anthropic:claude-sonnet-5' "
+        "(needs ANTHROPIC_API_KEY; falls back to the offline estimate)",
+    )
     sp.add_argument("--seed", type=int, default=None)
     sp.add_argument("--concurrency", type=int, default=None)
 
@@ -105,6 +111,7 @@ def _config_from_args(args: argparse.Namespace) -> ProbeConfig:
         "transport": getattr(args, "transport", None),
         "deep_security": _true_or_none(getattr(args, "deep_security", False)),
         "model": getattr(args, "model", None),
+        "token_model": getattr(args, "token_model", None),
         "seed": getattr(args, "seed", None),
         "concurrency": getattr(args, "concurrency", None),
         "families": _families_from_args(args) if hasattr(args, "all_families") else None,

--- a/src/mcp_probe/config.py
+++ b/src/mcp_probe/config.py
@@ -52,6 +52,9 @@ class ProbeConfig:
     # --- cost ---
     price_points: tuple[str, ...] = ()  # e.g. ("anthropic:claude-sonnet-5",); default set applied
     tokenizer: str = "o200k_base"  # deterministic offline tiktoken encoding (REQ-$4)
+    # Opt-in authoritative token counting, e.g. "anthropic:claude-sonnet-5". Needs
+    # ANTHROPIC_API_KEY; silently falls back to the offline tiktoken estimate otherwise.
+    token_model: str | None = None
 
     # --- performance ([net]) ---
     concurrency: int = 50

--- a/src/mcp_probe/engines/cost.py
+++ b/src/mcp_probe/engines/cost.py
@@ -19,8 +19,13 @@ from __future__ import annotations
 import math
 
 from mcp_probe.engines.base import EngineBase, clamp
-from mcp_probe.models import FamilyScore, Finding, ProbeContext, Severity
-from mcp_probe.tokens import TokenCounter, get_counter, serialize_toolset
+from mcp_probe.models import FamilyScore, Finding, ProbeContext, Severity, ToolDef
+from mcp_probe.tokens import (
+    TokenCounter,
+    anthropic_toolset_tokens,
+    get_counter,
+    serialize_toolset,
+)
 
 # Below this, a toolset is "lean" and scores ~100.
 TOKEN_BUDGET = 2000
@@ -67,14 +72,27 @@ class CostEngine(EngineBase):
                 metrics={"toolset_tokens": 0, "counter": counter.name, "tools": 0},
             )
 
-        toolset_tokens = counter.count(serialize_toolset(tools))
-
-        # Leave-one-out marginal attribution (REQ-$2).
+        # Offline leave-one-out gives deterministic *relative* per-tool weights (REQ-$2).
+        offline_total = counter.count(serialize_toolset(tools))
         per_tool: dict[str, int] = {}
         for t in tools:
             without = tuple(x for x in tools if x.name != t.name)
             without_tokens = counter.count(serialize_toolset(without)) if without else 0
-            per_tool[t.name] = max(0, toolset_tokens - without_tokens)
+            per_tool[t.name] = max(0, offline_total - without_tokens)
+
+        # Opt-in: use the authoritative Anthropic count for the headline total, then rescale
+        # the (relative) offline per-tool weights to it. Falls back to the offline estimate
+        # if no key / SDK / the call fails — the fast path stays keyless (REQ-$4).
+        toolset_tokens = offline_total
+        counter_name = counter.name
+        authoritative = self._authoritative_total(ctx, tools)
+        if authoritative is not None:
+            model = ctx.config.token_model.split(":", 1)[1]
+            counter_name = f"anthropic:count_tokens/{model}"
+            if offline_total > 0:
+                scale = authoritative / offline_total
+                per_tool = {n: max(0, round(w * scale)) for n, w in per_tool.items()}
+            toolset_tokens = authoritative
 
         findings: list[Finding] = []
         for name, weight in sorted(per_tool.items(), key=lambda kv: kv[1], reverse=True):
@@ -105,18 +123,19 @@ class CostEngine(EngineBase):
         score = cost_score(toolset_tokens)
         # Offline counters are OpenAI-family tokenizers; they UNDERCOUNT Claude by ~15-20%
         # (more on code / non-English). Label the number so it's never mistaken for a
-        # billing-grade Claude count. The authoritative path is a provider count_tokens.
+        # billing-grade Claude count. When the authoritative Anthropic count was used, the
+        # number is exact and the note is cleared.
         estimate_note = (
-            "estimate (OpenAI tokenizer; undercounts Claude ~15-20%)"
-            if counter.name != "provider"
-            else None
+            None
+            if counter_name.startswith("anthropic:")
+            else "estimate (OpenAI tokenizer; undercounts Claude ~15-20%)"
         )
         metrics = {
             "toolset_tokens": toolset_tokens,
             "per_tool_tokens": dict(sorted(per_tool.items(), key=lambda kv: kv[1], reverse=True)),
             "usd_per_task": usd_per_task,
             "usd_by_price_point": usd_by_point,
-            "counter": counter.name,
+            "counter": counter_name,
             "counter_note": estimate_note,
             "tools": len(tools),
         }
@@ -129,6 +148,16 @@ class CostEngine(EngineBase):
             findings=findings,
             metrics=metrics,
         )
+
+    @staticmethod
+    def _authoritative_total(ctx: ProbeContext, tools: tuple[ToolDef, ...]) -> int | None:
+        """Return an exact Anthropic token count if the user opted in via
+        ``token_model=anthropic:<model>`` and it succeeds; else None (→ offline estimate)."""
+        spec = getattr(ctx.config, "token_model", None)
+        if not spec or not spec.startswith("anthropic:"):
+            return None
+        model = spec.split(":", 1)[1]
+        return anthropic_toolset_tokens(tools, model)
 
     @staticmethod
     def _resolve_price_points(ctx: ProbeContext) -> dict[str, float]:

--- a/src/mcp_probe/engines/legibility.py
+++ b/src/mcp_probe/engines/legibility.py
@@ -106,6 +106,9 @@ class LegibilityEngine(EngineBase):
             "canonical": model.is_canonical,
             "cache_hit": probe["cache_hit"],
             "lexical_confusable_pairs": shortlist[:5],
+            "matrix": probe.get("matrix"),
+            "tool_order": probe.get("tool_order"),
+            "per_tool_total": probe.get("per_tool_total"),
         }
         return FamilyScore(
             family=self.name, score=score, grade=grade_for_score(score),
@@ -168,6 +171,12 @@ class LegibilityEngine(EngineBase):
             "top_confusion": top_confusion,
             "mean_confusion": mean_conf,
             "low_tools": low_tools,
+            # Full N×N disambiguation matrix (the screenshot-worthy artifact). Only the
+            # off-diagonal (confused) counts are stored; the renderer derives the diagonal
+            # from per_tool_total. Kept for surfaces small enough to display (<= 15 tools).
+            "matrix": {t: dict(c) for t, c in confusion.items()} if len(names) <= 15 else None,
+            "tool_order": names if len(names) <= 15 else None,
+            "per_tool_total": per_tool_total if len(names) <= 15 else None,
         }
 
     def _generate_rewrites(self, surface, model, probe) -> list[dict]:

--- a/src/mcp_probe/report/render.py
+++ b/src/mcp_probe/report/render.py
@@ -101,6 +101,54 @@ def render_terminal(report: Report, *, console: Console | None = None) -> str:
                 con.print(Text(f"      ↳ {f.remediation}", style="dim"))
 
     out = buffer.getvalue()
+
+    # The disambiguation matrix goes last — the headline artifact when legibility ran.
+    leg = report.families.get("legibility")
+    if leg is not None and leg.metrics.get("matrix"):
+        out += render_confusion_matrix(leg.metrics)
+
+    if console is not None:
+        console.print(out, end="")
+    return out
+
+
+def render_confusion_matrix(metrics: dict[str, Any], *, console: Console | None = None) -> str:
+    """The disambiguation matrix — the headline artifact (REQ-L2). Rows = the tool a goal
+    *should* pick; columns = the tool an agent actually picked. Off-diagonal mass is
+    confusion. Returns "" when no matrix is available (large surface / no model)."""
+    order = metrics.get("tool_order")
+    matrix = metrics.get("matrix")
+    totals = metrics.get("per_tool_total")
+    if not order or matrix is None or not totals:
+        return ""
+
+    buffer = io.StringIO()
+    con = Console(file=buffer, force_terminal=False, width=max(60, 14 + 6 * len(order)), highlight=False)
+    con.print(Text("\nDisambiguation matrix  (row = correct tool · cell = % of times chosen)", style=f"bold {OXBLOOD}"))
+
+    table = Table(show_header=True, header_style=f"bold {OXBLOOD}", padding=(0, 1))
+    table.add_column("correct ↓ / chose →", overflow="fold")
+    labels = [n[:6] for n in order]
+    for lab in labels:
+        table.add_column(lab, justify="right")
+
+    for true_tool in order:
+        total = totals.get(true_tool, 0) or 1
+        cells = []
+        for chosen in order:
+            if chosen == true_tool:
+                correct = total - sum(matrix.get(true_tool, {}).values())
+                rate = correct / total
+                cells.append(Text(f"{rate:.0%}", style="green" if rate >= 0.8 else "yellow"))
+            else:
+                count = matrix.get(true_tool, {}).get(chosen, 0)
+                rate = count / total
+                style = "bold red" if rate >= 0.3 else ("red" if rate > 0 else "dim")
+                cells.append(Text(f"{rate:.0%}" if rate else "·", style=style))
+        table.add_row(Text(true_tool[:18], style="cyan"), *cells)
+    con.print(table)
+
+    out = buffer.getvalue()
     if console is not None:
         console.print(out, end="")
     return out

--- a/src/mcp_probe/tokens.py
+++ b/src/mcp_probe/tokens.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Protocol
+from typing import Any, Protocol, cast
 
 from mcp_probe.models import ToolDef
 
@@ -75,3 +75,36 @@ def get_counter(encoding: str = "o200k_base") -> TokenCounter:
         return TiktokenCounter(encoding)
     except Exception:  # ImportError, or vocab fetch failed in an air-gapped env
         return HeuristicCounter()
+
+
+def anthropic_toolset_tokens(tools: tuple[ToolDef, ...], model: str) -> int | None:
+    """Authoritative, billing-grade Claude token count for the whole toolset via the
+    Anthropic ``count_tokens`` endpoint (REQ-$4). This is the ONLY accurate Claude count —
+    there is no offline Claude tokenizer.
+
+    Strictly opt-in and best-effort: returns ``None`` (→ caller falls back to the offline
+    estimate) if the ``anthropic`` SDK isn't installed, ``ANTHROPIC_API_KEY`` is absent, or
+    the call fails for any reason. Never raises. One network call: the tool array dominates
+    the count, so the minimal stub message's few-token overhead is negligible.
+    """
+    import os
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        return None
+    try:
+        from anthropic import Anthropic
+    except ImportError:
+        return None
+    try:
+        client = Anthropic()
+        # serialize_tool yields Anthropic's {name, description, input_schema} shape; cast
+        # past the SDK's precise ToolParam union (our dicts are structurally valid).
+        tool_params = cast("Any", [serialize_tool(t) for t in tools])
+        resp = client.messages.count_tokens(
+            model=model,
+            tools=tool_params,
+            messages=[{"role": "user", "content": "."}],
+        )
+        return int(resp.input_tokens)
+    except Exception:
+        return None

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -59,3 +59,35 @@ def test_heuristic_counter_deterministic():
     assert serialize_toolset(()) == "[]"
     c = HeuristicCounter()
     assert c.count("hello world foo") == c.count("hello world foo")
+
+
+async def test_authoritative_token_count_opt_in(monkeypatch):
+    # With token_model set and the Anthropic call "succeeding" (monkeypatched), the engine
+    # uses the authoritative total, clears the estimate note, and rescales per-tool weights.
+    import mcp_probe.engines.cost as cost_mod
+
+    monkeypatch.setattr(cost_mod, "anthropic_toolset_tokens", lambda tools, model: 9999)
+    tools = [
+        {"name": "a", "description": "short", "inputSchema": {"type": "object"}},
+        {"name": "b", "description": "word " * 100, "inputSchema": {"type": "object"}},
+    ]
+    ctx = make_ctx(tools, config=ProbeConfig(token_model="anthropic:claude-sonnet-5"))
+    fs = await cost_mod.CostEngine(counter=HeuristicCounter()).run(ctx)
+    assert fs.metrics["toolset_tokens"] == 9999
+    assert fs.metrics["counter"].startswith("anthropic:count_tokens/")
+    assert fs.metrics["counter_note"] is None  # authoritative → no estimate caveat
+    # per-tool weights rescaled to the authoritative total, still ordered b > a
+    per = fs.metrics["per_tool_tokens"]
+    assert per["b"] > per["a"]
+
+
+async def test_falls_back_to_estimate_when_authoritative_unavailable(monkeypatch):
+    # token_model set but the call returns None (no key / failure) → offline estimate, labeled.
+    import mcp_probe.engines.cost as cost_mod
+
+    monkeypatch.setattr(cost_mod, "anthropic_toolset_tokens", lambda tools, model: None)
+    tools = [{"name": "a", "description": "x", "inputSchema": {"type": "object"}}]
+    ctx = make_ctx(tools, config=ProbeConfig(token_model="anthropic:claude-sonnet-5"))
+    fs = await cost_mod.CostEngine(counter=HeuristicCounter()).run(ctx)
+    assert fs.metrics["counter"] == "heuristic"
+    assert "estimate" in fs.metrics["counter_note"]

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -81,3 +81,22 @@ def test_shields_endpoint_payload():
     ep = shields_endpoint("B")
     assert ep == {"schemaVersion": 1, "label": "mcp-probe", "message": "B", "color": "green"}
     json.dumps(ep)  # must be serializable
+
+
+def test_confusion_matrix_renders():
+    from mcp_probe.report.render import render_confusion_matrix
+
+    metrics = {
+        "matrix": {"archive_record": {"delete_record": 3}, "delete_record": {}},
+        "tool_order": ["delete_record", "archive_record"],
+        "per_tool_total": {"archive_record": 3, "delete_record": 3},
+    }
+    out = render_confusion_matrix(metrics)
+    assert "Disambiguation matrix" in out
+    assert "100%" in out  # archive fully confused with delete
+
+
+def test_confusion_matrix_empty_without_data():
+    from mcp_probe.report.render import render_confusion_matrix
+
+    assert render_confusion_matrix({"selection_rate": None}) == ""


### PR DESCRIPTION
Follows up the merged v0.1 (#5) with the launch-readiness work and one Cost accuracy upgrade.

## Disambiguation matrix (the headline artifact)
The legibility engine now exposes the full **N×N confusion matrix** (not just the top pair), with a color-coded terminal renderer: rows = the tool a goal should pick, cells = what the agent actually chose. Off-diagonal mass = confusion.

## Real leaderboard
`scripts/leaderboard.py` probes credential-free public MCP servers over npx/uvx and emits a ranked table. Run live against **7 real servers** → [`docs/leaderboard.md`](docs/leaderboard.md):

| Grade | Servers |
|---|---|
| A | server-memory (100), mcp-server-time (100), mcp-server-fetch (100), mcp-server-git (100), server-filesystem (99), server-everything (95) |
| D | server-sequential-thinking (67) — Contract hard-gate |

The `sequential-thinking` D is legitimate and explained: the determinism probe caught undeclared nondeterminism in its stateful tool. A footnote frames it as "declare the output volatile," not a verdict.

## Authoritative token counting (opt-in)
`--token-model anthropic:<model>` uses Anthropic `count_tokens` (accepts a `tools` array) for the exact Claude count of the headline total; per-tool weights stay on the offline leave-one-out, rescaled. **Silently falls back** to the labeled tiktoken estimate with no key — the fast path stays keyless.

## Demo assets
`scripts/demo.sh` (asciinema-ready) + [`docs/demo.md`](docs/demo.md) with the token tax and the matrix captured from real runs (a real Ollama model confuses `archive_record`↔`delete_record` 100% of the time).

## Quality
97 tests green (+2 for authoritative-token opt-in/fallback, +2 for the matrix renderer); ruff + mypy clean. `docs/DECISIONS.md` D1/D3 updated.