### PR TITLE
chore(release): prep v0.1.0 — PyPI publishing, changelog, launch essay

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+# Publishes to PyPI when a GitHub Release is published. Uses PyPI Trusted Publishing
+# (OIDC) — no API token/secret is stored anywhere. One-time setup on pypi.org:
+#   PyPI → project → Publishing → add a trusted publisher:
+#     owner=swarmproof  repo=mcp-probe  workflow=release.yml  environment=pypi
+# Then: create a GitHub Release tagged v0.1.0 → this workflow builds and uploads.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist + wheel
+        run: |
+          pip install build
+          python -m build
+      - name: Verify metadata
+        run: |
+          pip install twine
+          twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to mcp-probe are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/); versions follow [SemVer](https://semver.org/).
+
+## [0.1.0] — unreleased
+
+First public release: the CI quality suite for MCP servers. Grades any MCP server across
+five check families into a single **MCP Quality Score**, gates CI, and prints a badge.
+
+### Added
+- **Contract** `[fast]` — JSON-RPC/handshake conformance, JSON-Schema validity,
+  deterministic argument synthesis + invocation, output-shape conformance, and a
+  determinism probe. Read-only by default; destructive tools skipped unless `--allow-writes`.
+- **Cost** `[fast]` — whole-toolset token count, leave-one-out per-tool attribution,
+  $-per-task. Offline-deterministic (tiktoken, labeled as an estimate) with an **opt-in**
+  authoritative Anthropic `count_tokens` path (`--token-model anthropic:<model>`) that
+  falls back silently without a key.
+- **Security-lite** `[fast]` — injection/tool-poisoning, secrets (regex + entropy), and
+  dangerous-capability lints mapped to the **OWASP MCP Top 10** (`MCP01/03/05:2025`);
+  `--deep-security` folds in mcp-scan (Snyk) / Cisco findings when installed.
+- **Performance** `[net]` — concurrent load with real MCP semantics, p50/p95/p99, max
+  stable concurrency, degradation classification, and connection-leak detection.
+- **Legibility** `[llm]` — offline description lints + lexical confusable-shortlist
+  always; a seeded comprehension probe, an **N×N disambiguation matrix**, and proposed
+  rewrites when a model is configured. Results cached by
+  `(surface_hash, model, seed, goal_set)` — warm reruns invoke the model zero times.
+- Transports: **stdio**, **Streamable-HTTP**, and legacy **SSE**; version-aware
+  `initialize` handshake (spec `2025-11-25`).
+- CLI: `run` · `static` (offline/air-gapped) · `snapshot` (+ `--no-regressions`) · `badge`.
+- Outputs: graded terminal report, HTML, versioned JSON (`mcp-probe/report@1`) with
+  `--fail-under`, an SVG + shields.io badge, and the `stampede --from-probe` handoff seed.
+- Scoring: weighted mean (Cost 30 / Legibility 25 / Contract 20 / Performance 15 /
+  Security 10), hard-gate cap at C, versioned rubric (`2026.07.1`).
+- 97 tests (unit + component + integration + E2E over stdio & HTTP/SSE), an opt-in
+  `live_llm` suite, and a dogfooding CI (test / dogfood / determinism / offline jobs).
+- A reproducible [leaderboard](docs/leaderboard.md) of real public MCP servers and a
+  captured [demo](docs/demo.md).
+
+### Notes
+- Deviations from the design spec are recorded in [docs/DECISIONS.md](docs/DECISIONS.md)
+  (OWASP MCP Top 10 mapping; why the `2026-07-28` stateless `server/discover` path is not
+  yet implemented; the offline-token estimate).
+
+[0.1.0]: https://github.com/swarmproof/mcp-probe/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,30 @@ five check families into a single **MCP Quality Score**, gates CI, and prints a 
   `--fail-under`, an SVG + shields.io badge, and the `stampede --from-probe` handoff seed.
 - Scoring: weighted mean (Cost 30 / Legibility 25 / Contract 20 / Performance 15 /
   Security 10), hard-gate cap at C, versioned rubric (`2026.07.1`).
-- 97 tests (unit + component + integration + E2E over stdio & HTTP/SSE), an opt-in
-  `live_llm` suite, and a dogfooding CI (test / dogfood / determinism / offline jobs).
+- 139 tests (unit + component + integration + E2E over stdio & HTTP/SSE), opt-in
+  `live_llm` / `deep_security` suites, and a dogfooding CI (test / dogfood / determinism /
+  offline jobs).
 - A reproducible [leaderboard](docs/leaderboard.md) of real public MCP servers and a
   captured [demo](docs/demo.md).
+
+Also included (planned as the "v0.2" milestone, shipped in this first release):
+- **Legibility auto-fix** — `mcp-probe fix` applies the proposed description rewrites to
+  source (name-anchored find/replace), with `--apply` / `--pr` (REQ-L7).
+- **Historical tracking** — `mcp-probe run --record` + `mcp-probe compare` + a sticky PR
+  score-delta comment workflow.
+- **Cost** — response-bloat sampling (`--response-bloat`) and lazy-loading remediation
+  hints (REQ-$5/$6).
+- **Contract** — error-path conformance (malformed input must not crash) + deprecated-SSE
+  forward-compat lint (REQ-C9/C10).
+- **Security** — Cisco `readiness` analyzer folded into Performance/Contract (REQ-S6).
+- **Transport/gating** — HTTP/SSE auth headers (`--header`), per-family gates
+  (`--fail-under-family`).
+- **Registry scoring API** — `mcp-probe serve` (`POST /score` · `/verify` · `/healthz`),
+  in the `[registry]` extra.
+
+### Dependencies
+- Pinned `mcp>=1.28,<2`: SDK v2 renamed `FastMCP`→`MCPServer` and changed result-field
+  casing. Migration to v2 is tracked separately.
 
 ### Notes
 - Deviations from the design spec are recorded in [docs/DECISIONS.md](docs/DECISIONS.md)

--- a/docs/launch/essay.md
+++ b/docs/launch/essay.md
@@ -1,0 +1,112 @@
+# Your MCP server has a quality score. I graded the popular ones to show you what it looks like.
+
+*Draft — Show HN / blog launch essay for mcp-probe. Lead with the leaderboard and the
+token number; not security (crowded) and not RPS (boring).*
+
+---
+
+Every web app gets a Lighthouse score. Every repo gets a coverage badge. MCP servers —
+the tools your agents actually depend on — get nothing. You ship a server, an agent picks
+the wrong tool or burns 9,000 tokens just to *read* your tool list, and you find out in
+production, from a user, expensively.
+
+So I built **mcp-probe**: a CI quality suite that grades any MCP server across five
+dimensions into a single letter grade, gates your merge, and prints a badge. Then I
+pointed it at seven popular public servers. Here's what a quality score actually looks
+like.
+
+## The leaderboard
+
+```
+Server                         Grade  Score  Tools  Toolset tokens
+server-memory                    A     100     9     1,112
+mcp-server-time                  A     100     2       275
+mcp-server-fetch                 A     100     1       290
+mcp-server-git                   A     100    12     1,407
+server-filesystem                A      99    14     1,901
+server-everything                A      95    13     1,292
+server-sequential-thinking       D      67     1       918   ← contract hard-gate
+```
+
+Good news first: the official reference servers are **well built**. Lean tool surfaces,
+clear descriptions, no secrets, no injection surface. If you were expecting a wall of
+F's, that's not the honest result and I'm not going to fake it.
+
+But two things in that table should stop you.
+
+## 1. The token tax is invisible until something prints it
+
+`server-filesystem` costs **1,901 tokens** — every turn, for every agent, before it does
+anything. That's the price of *existing* in the context window. It's fine for one lean
+server. Now add five servers to your agent. Add a server that wasn't careful — I have a
+40-tool test fixture that clocks **8,792 tokens**, ~$0.026 per task at Sonnet prices,
+paid whether or not anything works. That's the single most actionable number in agent
+engineering and almost nobody measures it.
+
+mcp-probe measures it per-tool, using leave-one-out attribution, and tells you *which*
+tool to put on a diet:
+
+```
+$2-bloat  search_all  ~1,900 tokens  → tighten the schema, split the tool, or lazy-load
+```
+
+## 2. The failure that's one tool-pair away from every server
+
+`server-sequential-thinking` scored a D. Not because it's badly written — because its one
+tool is *stateful*, and mcp-probe's determinism probe called it twice with identical
+arguments and got two different answers. That's undeclared nondeterminism. For that server
+it's arguably by-design (the fix is to *declare* the output volatile, not to change
+behaviour) — but the check is exactly right, and it's the kind of thing that silently
+breaks agent retries.
+
+The scarier one doesn't need a stateful tool. Give me any two tools with similar
+descriptions and I'll show you an agent picking the wrong one. Here's a real run — two
+tools, both described *"Remove a record by id."*, judged by a small local model:
+
+```
+Disambiguation matrix  (row = correct tool · cell = % of times chosen)
+                       delete   archive
+  delete_record         100%       ·
+  archive_record        100%       0%     ← chose delete every time archive was right
+```
+
+`archive_record` was the right call and the model chose `delete_record` **100% of the
+time**. That's a data-loss bug living in your tool *descriptions*, invisible to every test
+you have — and mcp-probe not only catches it, it proposes the rewrite that fixes it.
+
+## "Isn't this just mcp-xray?"
+
+No, and credit where it's due: [mcp-xray](https://ralforion.com/mcp-xray.html) pioneered
+scoring token-tax and tool-confusion into a single grade, and I borrowed its
+leave-one-out token method outright. But mcp-xray is an **X-ray you run by hand**.
+mcp-probe is the thing in `.github/workflows` that **blocks the merge**. Four things the
+point tools don't do:
+
+1. **Load-test** with real MCP semantics (persistent connections, JSON-RPC — not naive HTTP).
+2. **Contract-test** — invoke tools, check output conformance, catch nondeterminism.
+3. **Snapshot** — diff against a committed baseline so a commit that silently breaks a
+   tool fails the PR.
+4. **Gate + badge** — a letter grade with a `--fail-under B` exit code and an
+   `mcp-probe: A` badge for your README.
+
+Security? It's *one* of the five checks — a floor, mapped to the OWASP MCP Top 10 — and
+for the deep stuff it shells out to the specialists (mcp-scan, Cisco) rather than
+reinventing them. This is a quality suite that treats security as a citizen, not the
+whole town.
+
+## Try it
+
+```bash
+pip install mcp-probe
+mcp-probe run "python my_server.py" --fail-under B
+```
+
+The zero-LLM fast path (contract + cost) runs deterministically in CI with no model and
+no key. Add `--legibility --model ollama:qwen2.5-3b` for the disambiguation matrix, or
+`--all` for everything.
+
+Run it on your server. Tell me what grade you got — and if it's a C, open the report;
+the fix is usually three sentences in a tool description.
+
+*mcp-probe is Apache-2.0 and part of the [Swarm Proof](https://github.com/swarmproof)
+toolkit — trust infrastructure for the agent economy.*


### PR DESCRIPTION
Release prep for the first public version. **No source changes** — packaging, automation, and launch content only.

## What's here
- **`.github/workflows/release.yml`** — publishes to PyPI on a GitHub Release via **Trusted Publishing (OIDC)**. No API token stored anywhere.
- **`CHANGELOG.md`** — the v0.1.0 entry (Keep a Changelog format).
- **`docs/launch/essay.md`** — the Show HN / blog draft, led by the real leaderboard and the token number.

## Verified locally
- `python -m build` → sdist + wheel; `twine check` **PASSED** on both.
- Clean-installed the wheel in a fresh venv → `mcp-probe --version` and a real `static` probe both work.

## Remaining steps to actually ship (need your action)
1. **Merge this PR.**
2. **Configure PyPI Trusted Publishing** (one-time): pypi.org → create project `mcp-probe` (or first upload) → Publishing → add trusted publisher `owner=swarmproof, repo=mcp-probe, workflow=release.yml, environment=pypi`.
3. **Tag + release:** `git tag v0.1.0 && git push origin v0.1.0`, then create the GitHub Release for `v0.1.0` (notes from `CHANGELOG.md`) → the workflow builds and publishes to PyPI.

After that, `pip install mcp-probe` is live and the README quickstart is real.

_Note: an untracked `AGENTS.md` (a Codex mirror of CLAUDE.md, created by external tooling) exists in the tree; I left it untracked rather than fold it into this release commit._