### PR TITLE
feat: legibility auto-fix — `mcp-probe fix` applies proposed rewrites (closes #8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Current state: v0.1 implemented (all five families)
+
+The v0.1 fast path and all five check families are implemented, tested, and dogfooded.
+Python 3.11+ (`src/` layout, `pip install`), official MCP SDK, `asyncio`. What deviates
+from the spec is recorded in **`docs/DECISIONS.md`** — read it before changing security
+IDs, the handshake, or the token counter.
+
+### Commands
+
+```bash
+python -m venv .venv && .venv/bin/pip install -e ".[dev]"   # setup
+
+.venv/bin/pytest -m "not live_llm" -q            # full suite (unit+component+integration+e2e)
+.venv/bin/pytest tests/test_scorer.py -q          # a single test file
+.venv/bin/pytest -m e2e -q                        # only the live-fixture E2E scenarios
+.venv/bin/pytest -m live_llm -q                   # opt-in, calls a real model (excluded by default)
+.venv/bin/ruff check src/ tests/                  # lint (line-length 110)
+.venv/bin/mypy src/                               # types (strict)
+
+.venv/bin/mcp-probe run ".venv/bin/python tests/servers/good_server.py"   # live probe
+.venv/bin/mcp-probe static tests/servers/dump.mcp.json --json             # offline
+.venv/bin/mcp-probe run "…" --all --model ollama:qwen2.5-3b               # all five families
+```
+
+Tests spawn fixture servers with the **same interpreter running pytest** (`sys.executable`),
+so they need the SDK installed in that env — always run via `.venv/bin/pytest`.
+
+### Package layout (`src/mcp_probe/`)
+
+- `models.py` — the frozen data model (`ServerSurface`/`Finding`/`FamilyScore`/`Report`/`CheckEngine`).
+- `config.py` · `cli.py` · `exit_codes.py` — config precedence, the 4 subcommands, CI exit codes.
+- `connect/` — `transport.py` is the **only** module importing the MCP SDK; `client.py` is the
+  façade + `FakeClient`; `discover.py` builds surfaces (live + static dump).
+- `engines/` — one file per family, each a pure `CheckEngine`; registered in `engines/__init__.py`.
+- `contract/`, `legibility/`, `security/`, `perf/`, `tokens.py` — engine-specific internals.
+- `scoring/` · `snapshot/` · `report/` · `handoff.py` · `trace.py` — aggregation & outputs.
+- `tests/servers/` — fixture MCP servers (the TEST-PLAN §2 matrix) + `dump.mcp.json`.
+
+## What mcp-probe is
+
+The **CI quality suite for MCP servers** — "the `pytest` + `lighthouse` for the servers agents depend on." It connects to an MCP server, discovers its surface, and grades it across **five check families** into a single A–F **MCP Quality Score**, designed to run as a CI gate with a README badge.
+
+Positioning is load-bearing and deliberate: security scanners (mcp-scan, Cisco) answer *"is this server dangerous?"*; mcp-probe answers *"is this server good?"* It treats security as **one light check**, defers deep security to the incumbents via `--deep-security` integration (never reimplements them), and unifies the quality *point* tools (credits mcp-xray as prior art) into a CI-native **suite and gate**. Do not drift the messaging toward "another scanner."
+
+The five families: **Contract** (LLM-free spec/schema/determinism), **Legibility** (the differentiator — agent-comprehension score + disambiguation matrix), **Cost** (toolset token weight), **Performance** (concurrent MCP-semantic load), **Security-lite** (OWASP MCP Top 10 basics + integration adapter).
+
+## Documentation hierarchy (read in this order)
+
+The docs are authoritative and layered — consult them before implementing anything:
+
+1. **`SPEC.md`** — the frozen v1.0 design spec/PRD. The baseline.
+2. **`docs/PRD.md`** — numbered, testable requirements: `REQ-*` (functional, per family) and `NFR-*` (non-functional). This is the requirement-of-record; code and tests reference these IDs.
+3. **`docs/ARCHITECTURE.md`** — system design, the core data model (`ServerSurface`, `Finding`, `FamilyScore`, `Report`, `CheckEngine`), the JSON output schema, and the **ADRs** (ADR-001..009) that bind implementation choices.
+4. **`docs/DELIVERY-PLAN.md`** — the WBS (`W0..W6`), effort sizing, critical path, and v0.1 Definition of Done.
+5. **`docs/TEST-PLAN.md`** — the acceptance backbone: E2E scenarios (`E2E-1..10`), the fixture server matrix, the `StubModel` determinism harness, and CI gates.
+6. **`docs/RESEARCH.md`** — the competitive/market analysis the positioning rests on.
+
+**Conventions in the docs that carry into code:**
+- The **`⊕ Beyond original spec`** marker flags anything extending the frozen v1.0 `SPEC.md`. Preserve it when editing docs; it tracks scope past the baseline.
+- Requirement IDs (`REQ-C4`, `NFR-2`, etc.) and finding codes (`C5-nondeterminism`, `S1-owasp-mcp05`) are stable identifiers — reference them in commits, tests, and `Finding.code`.
+- Tier labels: **[fast]** = zero-LLM deterministic, **[llm]** = needs a small model, **[net]** = needs a live server, **[static-ok]** = works offline in `static` mode.
+
+## Architecture: the binding decisions
+
+The system is a **pipeline**: `connect → discover → fan out to five engines → Scorer → Renderer/JSON/badge`. When implementing, these ADRs are constraints, not suggestions:
+
+- **ADR-001 — Engines are pure functions of `ServerSurface` (+ optional live client) → `FamilyScore`.** No engine mutates shared state; the Scorer and Renderer are the *only* aggregators. This is what makes the fast path deterministic and every engine testable with a fixed `ServerSurface` and no network/LLM. Adding a sixth family = implement the `CheckEngine` protocol and register it. **Smuggling shared mutable state into an engine violates the architecture.**
+- **ADR-002 — Zero-LLM fast path is the CI default.** Contract + Cost + Performance run with no model calls (`NFR-1`); Legibility is opt-in and off the critical path. The gate must be satisfiable by the fast path alone.
+- **ADR-003 — Version-aware connect.** The MCP spec is mid-transition (2025-11-25 legacy `initialize` handshake ↔ 2026-07-28 `server/discover` + `_meta`). Negotiate both, grade the result, require neither. This is the hardest correctness surface.
+- **ADR-004 — Canonical Legibility scorer = pinned local model, temp 0, fixed seed, cached by `(surface_hash, model_id, seed, goal_set_version)`.** Cloud models are opt-in and marked non-canonical. A rerun on an unchanged surface is a cache hit → ~$0, byte-identical.
+- **ADR-005 — `--deep-security` shells out and normalizes; never reimplements scanners.** Missing scanner → "not measured", never a failure.
+- **ADR-006 — `static` mode reports live-only checks as "not measured", never `0`.** Zeroing unmeasured checks is a bug (it punishes offline use and is gameable).
+- **ADR-009 — Read-only by default** (`NFR-9`); destructive tools (destructiveHint / heuristic) are skipped unless `--allow-writes`. Probing a `delete_*` tool must not fire it.
+
+### Determinism doctrine (the whole value prop)
+
+The tool grades code in CI, so its own output must be trustworthy:
+- **Fast path** (Contract/Cost/Security-lite built-in): **byte-identical** output for identical input, enforced by golden-file tests. No wall-clock or network-order dependence in scoring.
+- **Legibility**: deterministic only *under a fixed (model, seed, goal-set)*; tests use `StubModel` (never a real LLM) and assert the cache serves reruns with `call_count == 0`.
+- **Performance latencies**: inherently nondeterministic → assert *invariants* (percentile ordering `p50≤p95≤p99`, leak detection, degradation classification), never absolute ms.
+
+### Scoring rubric
+
+Weighted mean of five 0–100 sub-scores → letter grade. Default weights: **Cost 30%, Legibility 25%, Contract 20%, Performance 15%, Security-lite 10%** (see `docs/PRD.md` §7 for rationale). A family scoring **F caps overall at C** (the "hard-gate" — no A-grade server with a broken contract or critical security finding). Every report and badge carries `rubric_version` for cross-release comparability (`NFR-7`).
+
+### Shared primitives (vendored, bound to stampede's contracts)
+
+mcp-probe is project #3 of the seven-project **Swarm Proof** toolkit and reuses four primitives. The portfolio decision is **vendor-first**: copy minimal versions now rather than wait on extraction (~stampede v0.2). But the *contracts* are authoritative and must not be forked:
+- **concurrency-core** — the Performance load driver imports stampede's `Scheduler`/`Executor` **Protocol** and supplies uniform MCP-client tasks (not persona logic).
+- **report-renderer** — render via the shared `RunReport` model (oxblood style); register a `QualityScoreReport` view over it.
+- **trace-format** — **the OpenTelemetry GenAI semantic-conventions *profile*** (`gen_ai.*` spans + the `swarmproof.*` extension), *not* a bespoke schema. The `stampede --from-probe` handoff depends on cross-tool trace compatibility — consume the profile, don't fork it.
+- **persona-pack** — one minimal `naive` persona (`apiVersion: swarmproof.dev/persona/v1`) for the Legibility probe.
+
+## Working conventions
+
+- **Commits:** [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`), atomic, imperative mood, no AI attribution/signatures. Commit progressively as you go.
+- **Testability first:** because engines are pure functions, prefer a component test that feeds a fixed `ServerSurface` and asserts an exact `FamilyScore` over any test that needs a network or a real model. Live/LLM behavior belongs in integration/E2E with fakes (`StubModel`) or the opt-in, network-gated `-m live_llm` suite (excluded from the default/PR run).
+- **Dogfood:** the intended CI runs `mcp-probe` against its own `tests/servers/` fixtures — the tool must grade its own sample servers correctly (see `docs/TEST-PLAN.md` §9).
+- **Honest over impressive:** document boundaries; never zero an unmeasured check; mark non-canonical scores as such.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ classifiers = [
 # Core deps kept lean: the zero-LLM fast path (Contract + Cost) must install and run
 # without any model provider or heavy optional tooling (NFR-1, NFR-5).
 dependencies = [
-    "mcp>=1.0",              # official MCP SDK (client transports + ClientSession)
+    "mcp>=1.28,<2",          # official MCP SDK. Pinned to v1.x: v2 renamed FastMCP→MCPServer
+                             # and changed result field casing (isError→is_error). Migration
+                             # to v2 is tracked as its own issue.
     "jsonschema>=4.21",      # Contract: input/output schema validation (REQ-C3, REQ-C4)
     "tiktoken>=0.7",         # Cost: deterministic offline token counting (REQ-$4)
     "rich>=13.7",            # terminal report renderer (oxblood theme)

--- a/src/mcp_probe/cli.py
+++ b/src/mcp_probe/cli.py
@@ -52,6 +52,17 @@ def build_parser() -> argparse.ArgumentParser:
     badge.add_argument("--out", default="badge.svg", help="SVG output path")
     badge.add_argument("--endpoint-out", default=None, help="write the shields JSON endpoint too")
     badge.add_argument("--with-score", action="store_true", help="render 'A · 92' instead of 'A'")
+
+    # -- fix --
+    fix = sub.add_parser("fix", help="apply proposed legibility description rewrites (REQ-L7)")
+    fix.add_argument("target", nargs="?", help="stdio command / URL to probe, if no --from")
+    fix.add_argument("--source", required=True, help="source file whose tool descriptions to rewrite")
+    fix.add_argument("--from", dest="from_report", help="use rewrites from a saved report JSON")
+    fix.add_argument("--model", default=None, help="legibility model for a fresh probe")
+    fix.add_argument("--accept", default=None, help="comma-separated tool names to fix (default: all)")
+    fix.add_argument("--apply", action="store_true", help="write changes (default: dry-run diff)")
+    fix.add_argument("--pr", action="store_true", help="apply, commit on a branch, and open a PR via gh")
+    fix.add_argument("--allow-writes", action="store_true", help=argparse.SUPPRESS)
     return p
 
 
@@ -134,6 +145,8 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_badge(args)
     if args.command == "snapshot":
         return _cmd_snapshot(args)
+    if args.command == "fix":
+        return _cmd_fix(args)
     return _cmd_run(args)
 
 
@@ -217,6 +230,88 @@ def _cmd_badge(args: argparse.Namespace) -> int:
         Path(args.endpoint_out).write_text(
             json.dumps(shields_endpoint(grade)) + "\n", encoding="utf-8"
         )
+    return int(ExitCode.OK)
+
+
+def _cmd_fix(args: argparse.Namespace) -> int:
+    import json
+
+    from mcp_probe.fix import apply_to_file, collect_rewrites
+
+    only = set(args.accept.split(",")) if args.accept else None
+
+    # Source of rewrites: a saved report JSON, or a fresh legibility probe of the target.
+    if args.from_report:
+        report = json.loads(Path(args.from_report).read_text(encoding="utf-8"))
+    elif args.target:
+        from mcp_probe.pipeline import run_probe
+        from mcp_probe.report import report_to_dict
+
+        overrides = {
+            "target": args.target,
+            "families": ("contract", "cost", "legibility"),
+            "model": args.model,
+        }
+        config = load_config(cli_overrides={k: v for k, v in overrides.items() if v is not None})
+        try:
+            outcome = asyncio.run(run_probe(config))
+        except Exception as exc:
+            print(f"mcp-probe: probe error: {exc}", file=sys.stderr)
+            return int(ExitCode.PROBE_ERROR)
+        report = report_to_dict(outcome.report)
+    else:
+        print("mcp-probe: fix needs a target or --from report.json", file=sys.stderr)
+        return int(ExitCode.PROBE_ERROR)
+
+    rewrites = collect_rewrites(report, only=only)
+    if not rewrites:
+        print("mcp-probe: no applicable legibility rewrites found "
+              "(run with --legibility and a model, or check --accept)", file=sys.stderr)
+        return int(ExitCode.OK)
+
+    write = args.apply or args.pr
+    result = apply_to_file(args.source, rewrites, write=write)
+
+    for rw in result.applied:
+        print(f"  ✓ {rw.tool}: description rewritten")
+    for rw, reason in result.skipped:
+        print(f"  – {rw.tool}: skipped ({reason})", file=sys.stderr)
+    if result.diff and not write:
+        print("\n" + result.diff, end="")
+        print("(dry-run — pass --apply to write, or --pr to open a pull request)")
+
+    if not result.changed:
+        return int(ExitCode.OK)
+    if args.pr:
+        return _open_fix_pr(args.source, result)
+    if write:
+        print(f"\nmcp-probe: applied {len(result.applied)} rewrite(s) to {args.source}")
+    return int(ExitCode.OK)
+
+
+def _open_fix_pr(source: str, result: Any) -> int:
+    """Apply → branch → commit → PR via git + gh. Degrades to 'applied locally' on failure."""
+    import subprocess
+
+    branch = "mcp-probe/legibility-rewrites"
+    body = "Applies mcp-probe legibility description rewrites (REQ-L7):\n\n" + "\n".join(
+        f"- `{rw.tool}`" for rw in result.applied
+    )
+    steps = [
+        ["git", "checkout", "-b", branch],
+        ["git", "add", source],
+        ["git", "commit", "-m", "fix: apply mcp-probe legibility description rewrites"],
+        ["git", "push", "-u", "origin", branch],
+        ["gh", "pr", "create", "--title", "Apply mcp-probe legibility rewrites", "--body", body],
+    ]
+    try:
+        for step in steps:
+            subprocess.run(step, check=True, capture_output=True, text=True)  # noqa: S603
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        print(f"mcp-probe: changes applied locally; couldn't open PR automatically ({exc})",
+              file=sys.stderr)
+        return int(ExitCode.OK)
+    print(f"mcp-probe: opened PR from branch {branch}")
     return int(ExitCode.OK)
 
 

--- a/src/mcp_probe/engines/legibility.py
+++ b/src/mcp_probe/engines/legibility.py
@@ -195,8 +195,10 @@ class LegibilityEngine(EngineBase):
             tool = surface.tool(name)
             if tool is None:
                 continue
-            rewrite = model.propose_rewrite(name, tool.description or "", confusers.get(name, []))
-            rewrites.append({"tool": name, "rewrite": rewrite})
+            old = tool.description or ""
+            rewrite = model.propose_rewrite(name, old, confusers.get(name, []))
+            # Carry the exact old text so `mcp-probe fix` can find-and-replace it safely.
+            rewrites.append({"tool": name, "rewrite": rewrite, "old": old})
         return rewrites
 
     @staticmethod
@@ -221,6 +223,8 @@ class LegibilityEngine(EngineBase):
                     tool=entry["tool"],
                     message=f"'{entry['tool']}' is hard to select; a clearer description would help",
                     remediation=f"proposed: {entry['rewrite']}",
+                    # `mcp-probe fix` consumes old/rewrite to apply the change to source (REQ-L7).
+                    evidence={"old": entry.get("old", ""), "rewrite": entry["rewrite"]},
                 )
             )
         return findings

--- a/src/mcp_probe/fix.py
+++ b/src/mcp_probe/fix.py
@@ -1,0 +1,127 @@
+"""Legibility auto-fix (REQ-L7) — apply the description rewrites mcp-probe proposes.
+
+The diagnosis→fix loop: `run --legibility` emits `L5-rewrite` findings carrying the exact
+`old` description and a proposed `rewrite` (in each finding's ``evidence``). This module
+finds the old text in a target source file and replaces it with the rewrite, safely:
+
+* **Exact-match only** — the scanned description must appear verbatim in the source, or the
+  rewrite is skipped (never a fuzzy edit).
+* **Ambiguity guard** — if the old text appears more than once, skip it (can't tell which).
+* **Dry-run by default** — callers opt in to writing; opening a PR is a further opt-in.
+
+Servers that build descriptions dynamically won't match; that's reported, not forced.
+"""
+
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Rewrite:
+    tool: str
+    old: str
+    new: str
+
+
+@dataclass
+class ApplyResult:
+    applied: list[Rewrite] = field(default_factory=list)
+    skipped: list[tuple[Rewrite, str]] = field(default_factory=list)  # (rewrite, reason)
+    diff: str = ""
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.applied)
+
+
+def collect_rewrites(report: dict[str, Any], *, only: set[str] | None = None) -> list[Rewrite]:
+    """Pull (tool, old, new) rewrites out of a report's legibility L5-rewrite findings."""
+    leg = report.get("families", {}).get("legibility", {})
+    out: list[Rewrite] = []
+    for f in leg.get("findings", []):
+        if f.get("code") != "L5-rewrite":
+            continue
+        ev = f.get("evidence") or {}
+        old, new = ev.get("old"), ev.get("rewrite")
+        tool = f.get("tool")
+        if not old or not new or not tool:
+            continue  # nothing safely applicable (e.g. an empty original description)
+        if only is not None and tool not in only:
+            continue
+        out.append(Rewrite(tool=tool, old=old, new=new))
+    return out
+
+
+def _occurrences(text: str, needle: str) -> list[int]:
+    idx, out = text.find(needle), []
+    while idx != -1:
+        out.append(idx)
+        idx = text.find(needle, idx + 1)
+    return out
+
+
+def _locate(text: str, rw: Rewrite) -> tuple[int | None, str]:
+    """Return (start_index, reason). When the old text repeats, pick the occurrence
+    *nearest* the tool's name (decorator-style servers put them adjacent); a tie is
+    ambiguous and skipped. Sequential application also helps: once one identical
+    description is rewritten, the next becomes unique."""
+    occ = _occurrences(text, rw.old)
+    if not occ:
+        return None, "original description not found in source (dynamic?)"
+    if len(occ) == 1:
+        return occ[0], ""
+    tool_pos = _occurrences(text, rw.tool)
+    if not tool_pos:
+        return None, f"original appears {len(occ)}× and tool name '{rw.tool}' not in source — skipped"
+
+    def nearest(i: int) -> int:
+        return min(abs(i - tp) for tp in tool_pos)
+
+    ranked = sorted(occ, key=nearest)
+    if len(ranked) >= 2 and nearest(ranked[0]) == nearest(ranked[1]):
+        return None, f"original appears {len(occ)}× and can't be anchored to '{rw.tool}' — skipped"
+    return ranked[0], ""
+
+
+def apply_rewrites(source: str, rewrites: list[Rewrite]) -> tuple[str, ApplyResult]:
+    """Apply rewrites to ``source`` text. Returns (new_source, result). Pure — no I/O.
+
+    Replacement is index-based and re-scans after each edit, so shifting offsets are
+    handled and repeated descriptions are disambiguated by tool-name proximity."""
+    result = ApplyResult()
+    updated = source
+    for rw in rewrites:
+        if rw.old == rw.new:
+            result.skipped.append((rw, "rewrite identical to original"))
+            continue
+        start, reason = _locate(updated, rw)
+        if start is None:
+            result.skipped.append((rw, reason))
+            continue
+        updated = updated[:start] + rw.new + updated[start + len(rw.old):]
+        result.applied.append(rw)
+
+    if result.applied:
+        result.diff = "".join(
+            difflib.unified_diff(
+                source.splitlines(keepends=True),
+                updated.splitlines(keepends=True),
+                fromfile="a/source",
+                tofile="b/source",
+            )
+        )
+    return updated, result
+
+
+def apply_to_file(path: str | Path, rewrites: list[Rewrite], *, write: bool) -> ApplyResult:
+    """Apply rewrites to a file. ``write=False`` computes the diff without touching disk."""
+    p = Path(path)
+    source = p.read_text(encoding="utf-8")
+    updated, result = apply_rewrites(source, rewrites)
+    if write and result.changed:
+        p.write_text(updated, encoding="utf-8")
+    return result

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -1,0 +1,105 @@
+"""Legibility auto-fix tests (REQ-L7, issue #8) — collect + apply rewrites, incl. the
+name-anchoring that resolves identical descriptions, and an e2e through the CLI."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from mcp_probe.cli import main
+from mcp_probe.fix import Rewrite, apply_rewrites, collect_rewrites
+
+SERVERS = Path(__file__).parent / "servers"
+
+
+def _report_with_rewrites(entries: list[dict]) -> dict:
+    return {
+        "families": {
+            "legibility": {
+                "findings": [
+                    {"code": "L5-rewrite", "tool": e["tool"],
+                     "evidence": {"old": e["old"], "rewrite": e["new"]}}
+                    for e in entries
+                ]
+            }
+        }
+    }
+
+
+def test_collect_rewrites_pulls_old_and_new():
+    report = _report_with_rewrites([{"tool": "t", "old": "Old.", "new": "New, clearer."}])
+    rws = collect_rewrites(report)
+    assert rws == [Rewrite(tool="t", old="Old.", new="New, clearer.")]
+
+
+def test_collect_rewrites_respects_accept_filter():
+    report = _report_with_rewrites([
+        {"tool": "a", "old": "A", "new": "AA"},
+        {"tool": "b", "old": "B", "new": "BB"},
+    ])
+    assert [r.tool for r in collect_rewrites(report, only={"b"})] == ["b"]
+
+
+def test_apply_exact_single_match():
+    src = 'description="Old text here."\n'
+    out, res = apply_rewrites(src, [Rewrite("t", "Old text here.", "New text.")])
+    assert "New text." in out and "Old text here." not in out
+    assert res.applied and not res.skipped
+
+
+def test_apply_skips_when_not_found():
+    _out, res = apply_rewrites("nothing matches", [Rewrite("t", "absent", "x")])
+    assert not res.applied
+    assert "not found" in res.skipped[0][1]
+
+
+def test_apply_name_anchors_identical_descriptions():
+    # Both tools share the same description string — the confusable case. Anchoring by the
+    # tool name must send each rewrite to the right occurrence.
+    src = (
+        'def delete_record():\n    description="Remove a record by id."\n\n'
+        'def archive_record():\n    description="Remove a record by id."\n'
+    )
+    rws = [
+        Rewrite("delete_record", "Remove a record by id.", "Permanently delete a record by id."),
+        Rewrite("archive_record", "Remove a record by id.", "Move a record to the archive."),
+    ]
+    out, res = apply_rewrites(src, rws)
+    assert len(res.applied) == 2
+    # each rewrite landed next to its own function
+    assert "def delete_record():\n    description=\"Permanently delete a record by id.\"" in out
+    assert "def archive_record():\n    description=\"Move a record to the archive.\"" in out
+
+
+def test_cli_fix_apply_changes_confusable_server(tmp_path):
+    # e2e: apply real rewrites to a copy of the confusable fixture via the CLI.
+    src = tmp_path / "confusable_server.py"
+    shutil.copy(SERVERS / "confusable_server.py", src)
+    report = tmp_path / "report.json"
+    report.write_text(json.dumps(_report_with_rewrites([
+        {"tool": "delete_record", "old": "Remove a record by id.",
+         "new": "Permanently delete a record by id (cannot be undone)."},
+        {"tool": "archive_record", "old": "Remove a record by id.",
+         "new": "Move a record to the archive; reversible."},
+    ])), encoding="utf-8")
+
+    rc = main(["fix", "--from", str(report), "--source", str(src), "--apply"])
+    assert rc == 0
+    text = src.read_text(encoding="utf-8")
+    assert "Permanently delete a record by id" in text
+    assert "Move a record to the archive" in text
+    assert "Remove a record by id." not in text  # both originals rewritten
+
+
+def test_cli_fix_dry_run_does_not_write(tmp_path):
+    src = tmp_path / "s.py"
+    src.write_text('description="Remove a record by id."\n', encoding="utf-8")
+    report = tmp_path / "r.json"
+    report.write_text(json.dumps(_report_with_rewrites([
+        {"tool": "delete_record", "old": "Remove a record by id.", "new": "Delete it."},
+    ])), encoding="utf-8")
+    before = src.read_text(encoding="utf-8")
+    rc = main(["fix", "--from", str(report), "--source", str(src)])  # no --apply
+    assert rc == 0
+    assert src.read_text(encoding="utf-8") == before  # unchanged


### PR DESCRIPTION
Closes #8 (REQ-L7). Turns the rewrites we already *generate* into applied source changes — the diagnosis→fix loop.

## What
- New `mcp-probe fix <target|--from report.json> --source <file>` subcommand.
- `L5-rewrite` findings now carry the exact `old` + proposed `rewrite` in `evidence`, so `fix` can find-and-replace precisely.
- **Safety**: exact-match only; dry-run by default (`--apply` writes, `--pr` opens a PR via gh); re-scans after each edit.
- **Name-anchoring**: when two tools share an identical description (the canonical `delete`⇄`archive` case), each rewrite is routed to the occurrence nearest its tool name — ties are skipped, not guessed.

## e2e verified
- Unit + CLI tests (`tests/test_fix.py`, 7 tests) incl. the identical-description anchoring case.
- **Live**: `mcp-probe fix … --model ollama:mistral-small:latest --apply` on the confusable fixture rewrote both identical descriptions into distinct, clearer ones (2 → 0 occurrences of the ambiguous string). Full suite: **104 passing**, ruff + mypy clean.

## Merge order
First in the stacked v0.2 series (#8 → #9 → #11 → #12 → #13 → #14 → #10). Branches off `main`.