### PR TITLE
feat(cost): response-bloat + remediation hints (closes #11)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Current state: v0.1 implemented (all five families)
+
+The v0.1 fast path and all five check families are implemented, tested, and dogfooded.
+Python 3.11+ (`src/` layout, `pip install`), official MCP SDK, `asyncio`. What deviates
+from the spec is recorded in **`docs/DECISIONS.md`** — read it before changing security
+IDs, the handshake, or the token counter.
+
+### Commands
+
+```bash
+python -m venv .venv && .venv/bin/pip install -e ".[dev]"   # setup
+
+.venv/bin/pytest -m "not live_llm" -q            # full suite (unit+component+integration+e2e)
+.venv/bin/pytest tests/test_scorer.py -q          # a single test file
+.venv/bin/pytest -m e2e -q                        # only the live-fixture E2E scenarios
+.venv/bin/pytest -m live_llm -q                   # opt-in, calls a real model (excluded by default)
+.venv/bin/ruff check src/ tests/                  # lint (line-length 110)
+.venv/bin/mypy src/                               # types (strict)
+
+.venv/bin/mcp-probe run ".venv/bin/python tests/servers/good_server.py"   # live probe
+.venv/bin/mcp-probe static tests/servers/dump.mcp.json --json             # offline
+.venv/bin/mcp-probe run "…" --all --model ollama:qwen2.5-3b               # all five families
+```
+
+Tests spawn fixture servers with the **same interpreter running pytest** (`sys.executable`),
+so they need the SDK installed in that env — always run via `.venv/bin/pytest`.
+
+### Package layout (`src/mcp_probe/`)
+
+- `models.py` — the frozen data model (`ServerSurface`/`Finding`/`FamilyScore`/`Report`/`CheckEngine`).
+- `config.py` · `cli.py` · `exit_codes.py` — config precedence, the 4 subcommands, CI exit codes.
+- `connect/` — `transport.py` is the **only** module importing the MCP SDK; `client.py` is the
+  façade + `FakeClient`; `discover.py` builds surfaces (live + static dump).
+- `engines/` — one file per family, each a pure `CheckEngine`; registered in `engines/__init__.py`.
+- `contract/`, `legibility/`, `security/`, `perf/`, `tokens.py` — engine-specific internals.
+- `scoring/` · `snapshot/` · `report/` · `handoff.py` · `trace.py` — aggregation & outputs.
+- `tests/servers/` — fixture MCP servers (the TEST-PLAN §2 matrix) + `dump.mcp.json`.
+
+## What mcp-probe is
+
+The **CI quality suite for MCP servers** — "the `pytest` + `lighthouse` for the servers agents depend on." It connects to an MCP server, discovers its surface, and grades it across **five check families** into a single A–F **MCP Quality Score**, designed to run as a CI gate with a README badge.
+
+Positioning is load-bearing and deliberate: security scanners (mcp-scan, Cisco) answer *"is this server dangerous?"*; mcp-probe answers *"is this server good?"* It treats security as **one light check**, defers deep security to the incumbents via `--deep-security` integration (never reimplements them), and unifies the quality *point* tools (credits mcp-xray as prior art) into a CI-native **suite and gate**. Do not drift the messaging toward "another scanner."
+
+The five families: **Contract** (LLM-free spec/schema/determinism), **Legibility** (the differentiator — agent-comprehension score + disambiguation matrix), **Cost** (toolset token weight), **Performance** (concurrent MCP-semantic load), **Security-lite** (OWASP MCP Top 10 basics + integration adapter).
+
+## Documentation hierarchy (read in this order)
+
+The docs are authoritative and layered — consult them before implementing anything:
+
+1. **`SPEC.md`** — the frozen v1.0 design spec/PRD. The baseline.
+2. **`docs/PRD.md`** — numbered, testable requirements: `REQ-*` (functional, per family) and `NFR-*` (non-functional). This is the requirement-of-record; code and tests reference these IDs.
+3. **`docs/ARCHITECTURE.md`** — system design, the core data model (`ServerSurface`, `Finding`, `FamilyScore`, `Report`, `CheckEngine`), the JSON output schema, and the **ADRs** (ADR-001..009) that bind implementation choices.
+4. **`docs/DELIVERY-PLAN.md`** — the WBS (`W0..W6`), effort sizing, critical path, and v0.1 Definition of Done.
+5. **`docs/TEST-PLAN.md`** — the acceptance backbone: E2E scenarios (`E2E-1..10`), the fixture server matrix, the `StubModel` determinism harness, and CI gates.
+6. **`docs/RESEARCH.md`** — the competitive/market analysis the positioning rests on.
+
+**Conventions in the docs that carry into code:**
+- The **`⊕ Beyond original spec`** marker flags anything extending the frozen v1.0 `SPEC.md`. Preserve it when editing docs; it tracks scope past the baseline.
+- Requirement IDs (`REQ-C4`, `NFR-2`, etc.) and finding codes (`C5-nondeterminism`, `S1-owasp-mcp05`) are stable identifiers — reference them in commits, tests, and `Finding.code`.
+- Tier labels: **[fast]** = zero-LLM deterministic, **[llm]** = needs a small model, **[net]** = needs a live server, **[static-ok]** = works offline in `static` mode.
+
+## Architecture: the binding decisions
+
+The system is a **pipeline**: `connect → discover → fan out to five engines → Scorer → Renderer/JSON/badge`. When implementing, these ADRs are constraints, not suggestions:
+
+- **ADR-001 — Engines are pure functions of `ServerSurface` (+ optional live client) → `FamilyScore`.** No engine mutates shared state; the Scorer and Renderer are the *only* aggregators. This is what makes the fast path deterministic and every engine testable with a fixed `ServerSurface` and no network/LLM. Adding a sixth family = implement the `CheckEngine` protocol and register it. **Smuggling shared mutable state into an engine violates the architecture.**
+- **ADR-002 — Zero-LLM fast path is the CI default.** Contract + Cost + Performance run with no model calls (`NFR-1`); Legibility is opt-in and off the critical path. The gate must be satisfiable by the fast path alone.
+- **ADR-003 — Version-aware connect.** The MCP spec is mid-transition (2025-11-25 legacy `initialize` handshake ↔ 2026-07-28 `server/discover` + `_meta`). Negotiate both, grade the result, require neither. This is the hardest correctness surface.
+- **ADR-004 — Canonical Legibility scorer = pinned local model, temp 0, fixed seed, cached by `(surface_hash, model_id, seed, goal_set_version)`.** Cloud models are opt-in and marked non-canonical. A rerun on an unchanged surface is a cache hit → ~$0, byte-identical.
+- **ADR-005 — `--deep-security` shells out and normalizes; never reimplements scanners.** Missing scanner → "not measured", never a failure.
+- **ADR-006 — `static` mode reports live-only checks as "not measured", never `0`.** Zeroing unmeasured checks is a bug (it punishes offline use and is gameable).
+- **ADR-009 — Read-only by default** (`NFR-9`); destructive tools (destructiveHint / heuristic) are skipped unless `--allow-writes`. Probing a `delete_*` tool must not fire it.
+
+### Determinism doctrine (the whole value prop)
+
+The tool grades code in CI, so its own output must be trustworthy:
+- **Fast path** (Contract/Cost/Security-lite built-in): **byte-identical** output for identical input, enforced by golden-file tests. No wall-clock or network-order dependence in scoring.
+- **Legibility**: deterministic only *under a fixed (model, seed, goal-set)*; tests use `StubModel` (never a real LLM) and assert the cache serves reruns with `call_count == 0`.
+- **Performance latencies**: inherently nondeterministic → assert *invariants* (percentile ordering `p50≤p95≤p99`, leak detection, degradation classification), never absolute ms.
+
+### Scoring rubric
+
+Weighted mean of five 0–100 sub-scores → letter grade. Default weights: **Cost 30%, Legibility 25%, Contract 20%, Performance 15%, Security-lite 10%** (see `docs/PRD.md` §7 for rationale). A family scoring **F caps overall at C** (the "hard-gate" — no A-grade server with a broken contract or critical security finding). Every report and badge carries `rubric_version` for cross-release comparability (`NFR-7`).
+
+### Shared primitives (vendored, bound to stampede's contracts)
+
+mcp-probe is project #3 of the seven-project **Swarm Proof** toolkit and reuses four primitives. The portfolio decision is **vendor-first**: copy minimal versions now rather than wait on extraction (~stampede v0.2). But the *contracts* are authoritative and must not be forked:
+- **concurrency-core** — the Performance load driver imports stampede's `Scheduler`/`Executor` **Protocol** and supplies uniform MCP-client tasks (not persona logic).
+- **report-renderer** — render via the shared `RunReport` model (oxblood style); register a `QualityScoreReport` view over it.
+- **trace-format** — **the OpenTelemetry GenAI semantic-conventions *profile*** (`gen_ai.*` spans + the `swarmproof.*` extension), *not* a bespoke schema. The `stampede --from-probe` handoff depends on cross-tool trace compatibility — consume the profile, don't fork it.
+- **persona-pack** — one minimal `naive` persona (`apiVersion: swarmproof.dev/persona/v1`) for the Legibility probe.
+
+## Working conventions
+
+- **Commits:** [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`), atomic, imperative mood, no AI attribution/signatures. Commit progressively as you go.
+- **Testability first:** because engines are pure functions, prefer a component test that feeds a fixed `ServerSurface` and asserts an exact `FamilyScore` over any test that needs a network or a real model. Live/LLM behavior belongs in integration/E2E with fakes (`StubModel`) or the opt-in, network-gated `-m live_llm` suite (excluded from the default/PR run).
+- **Dogfood:** the intended CI runs `mcp-probe` against its own `tests/servers/` fixtures — the tool must grade its own sample servers correctly (see `docs/TEST-PLAN.md` §9).
+- **Honest over impressive:** document boundaries; never zero an unmeasured check; mark non-canonical scores as such.

--- a/docs/examples/score-delta-workflow.yml
+++ b/docs/examples/score-delta-workflow.yml
@@ -1,0 +1,50 @@
+# Example: post a sticky "MCP Quality Score change" comment on every PR.
+# Copy to .github/workflows/ in your MCP server repo and set MCP_TARGET.
+# Scores the base and the PR head, diffs them, and updates one comment in place.
+name: MCP Quality delta
+on: pull_request
+
+permissions:
+  contents: read
+  pull-requests: write   # to post/update the comment
+
+env:
+  MCP_TARGET: "python my_server.py"   # <-- your server's launch command
+
+jobs:
+  score-delta:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mcp-probe
+
+      - name: Score PR head
+        run: mcp-probe run "$MCP_TARGET" --json > head.json
+
+      - name: Score base
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }} -- . || git checkout ${{ github.event.pull_request.base.sha }}
+          mcp-probe run "$MCP_TARGET" --json > base.json
+          git checkout ${{ github.sha }} -- . 2>/dev/null || true
+
+      - name: Build the delta comment
+        run: mcp-probe compare base.json head.json --markdown > delta.md
+
+      - name: Post or update the sticky comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          # find our previous comment by its hidden marker, edit it if present else create
+          id=$(gh api "repos/${{ github.repository }}/issues/$PR/comments" \
+                 --jq '.[] | select(.body | contains("<!-- mcp-probe-score-delta -->")) | .id' | head -1)
+          if [ -n "$id" ]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$id" -F body=@delta.md
+          else
+            gh pr comment "$PR" --body-file delta.md
+          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ classifiers = [
 # Core deps kept lean: the zero-LLM fast path (Contract + Cost) must install and run
 # without any model provider or heavy optional tooling (NFR-1, NFR-5).
 dependencies = [
-    "mcp>=1.0",              # official MCP SDK (client transports + ClientSession)
+    "mcp>=1.28,<2",          # official MCP SDK. Pinned to v1.x: v2 renamed FastMCP→MCPServer
+                             # and changed result field casing (isError→is_error). Migration
+                             # to v2 is tracked as its own issue.
     "jsonschema>=4.21",      # Contract: input/output schema validation (REQ-C3, REQ-C4)
     "tiktoken>=0.7",         # Cost: deterministic offline token counting (REQ-$4)
     "rich>=13.7",            # terminal report renderer (oxblood theme)

--- a/src/mcp_probe/cli.py
+++ b/src/mcp_probe/cli.py
@@ -52,6 +52,17 @@ def build_parser() -> argparse.ArgumentParser:
     badge.add_argument("--out", default="badge.svg", help="SVG output path")
     badge.add_argument("--endpoint-out", default=None, help="write the shields JSON endpoint too")
     badge.add_argument("--with-score", action="store_true", help="render 'A · 92' instead of 'A'")
+
+    # -- fix --
+    fix = sub.add_parser("fix", help="apply proposed legibility description rewrites (REQ-L7)")
+    fix.add_argument("target", nargs="?", help="stdio command / URL to probe, if no --from")
+    fix.add_argument("--source", required=True, help="source file whose tool descriptions to rewrite")
+    fix.add_argument("--from", dest="from_report", help="use rewrites from a saved report JSON")
+    fix.add_argument("--model", default=None, help="legibility model for a fresh probe")
+    fix.add_argument("--accept", default=None, help="comma-separated tool names to fix (default: all)")
+    fix.add_argument("--apply", action="store_true", help="write changes (default: dry-run diff)")
+    fix.add_argument("--pr", action="store_true", help="apply, commit on a branch, and open a PR via gh")
+    fix.add_argument("--allow-writes", action="store_true", help=argparse.SUPPRESS)
     return p
 
 
@@ -134,6 +145,8 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_badge(args)
     if args.command == "snapshot":
         return _cmd_snapshot(args)
+    if args.command == "fix":
+        return _cmd_fix(args)
     return _cmd_run(args)
 
 
@@ -217,6 +230,88 @@ def _cmd_badge(args: argparse.Namespace) -> int:
         Path(args.endpoint_out).write_text(
             json.dumps(shields_endpoint(grade)) + "\n", encoding="utf-8"
         )
+    return int(ExitCode.OK)
+
+
+def _cmd_fix(args: argparse.Namespace) -> int:
+    import json
+
+    from mcp_probe.fix import apply_to_file, collect_rewrites
+
+    only = set(args.accept.split(",")) if args.accept else None
+
+    # Source of rewrites: a saved report JSON, or a fresh legibility probe of the target.
+    if args.from_report:
+        report = json.loads(Path(args.from_report).read_text(encoding="utf-8"))
+    elif args.target:
+        from mcp_probe.pipeline import run_probe
+        from mcp_probe.report import report_to_dict
+
+        overrides = {
+            "target": args.target,
+            "families": ("contract", "cost", "legibility"),
+            "model": args.model,
+        }
+        config = load_config(cli_overrides={k: v for k, v in overrides.items() if v is not None})
+        try:
+            outcome = asyncio.run(run_probe(config))
+        except Exception as exc:
+            print(f"mcp-probe: probe error: {exc}", file=sys.stderr)
+            return int(ExitCode.PROBE_ERROR)
+        report = report_to_dict(outcome.report)
+    else:
+        print("mcp-probe: fix needs a target or --from report.json", file=sys.stderr)
+        return int(ExitCode.PROBE_ERROR)
+
+    rewrites = collect_rewrites(report, only=only)
+    if not rewrites:
+        print("mcp-probe: no applicable legibility rewrites found "
+              "(run with --legibility and a model, or check --accept)", file=sys.stderr)
+        return int(ExitCode.OK)
+
+    write = args.apply or args.pr
+    result = apply_to_file(args.source, rewrites, write=write)
+
+    for rw in result.applied:
+        print(f"  ✓ {rw.tool}: description rewritten")
+    for rw, reason in result.skipped:
+        print(f"  – {rw.tool}: skipped ({reason})", file=sys.stderr)
+    if result.diff and not write:
+        print("\n" + result.diff, end="")
+        print("(dry-run — pass --apply to write, or --pr to open a pull request)")
+
+    if not result.changed:
+        return int(ExitCode.OK)
+    if args.pr:
+        return _open_fix_pr(args.source, result)
+    if write:
+        print(f"\nmcp-probe: applied {len(result.applied)} rewrite(s) to {args.source}")
+    return int(ExitCode.OK)
+
+
+def _open_fix_pr(source: str, result: Any) -> int:
+    """Apply → branch → commit → PR via git + gh. Degrades to 'applied locally' on failure."""
+    import subprocess
+
+    branch = "mcp-probe/legibility-rewrites"
+    body = "Applies mcp-probe legibility description rewrites (REQ-L7):\n\n" + "\n".join(
+        f"- `{rw.tool}`" for rw in result.applied
+    )
+    steps = [
+        ["git", "checkout", "-b", branch],
+        ["git", "add", source],
+        ["git", "commit", "-m", "fix: apply mcp-probe legibility description rewrites"],
+        ["git", "push", "-u", "origin", branch],
+        ["gh", "pr", "create", "--title", "Apply mcp-probe legibility rewrites", "--body", body],
+    ]
+    try:
+        for step in steps:
+            subprocess.run(step, check=True, capture_output=True, text=True)  # noqa: S603
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        print(f"mcp-probe: changes applied locally; couldn't open PR automatically ({exc})",
+              file=sys.stderr)
+        return int(ExitCode.OK)
+    print(f"mcp-probe: opened PR from branch {branch}")
     return int(ExitCode.OK)
 
 

--- a/src/mcp_probe/cli.py
+++ b/src/mcp_probe/cli.py
@@ -63,6 +63,13 @@ def build_parser() -> argparse.ArgumentParser:
     fix.add_argument("--apply", action="store_true", help="write changes (default: dry-run diff)")
     fix.add_argument("--pr", action="store_true", help="apply, commit on a branch, and open a PR via gh")
     fix.add_argument("--allow-writes", action="store_true", help=argparse.SUPPRESS)
+
+    # -- compare --
+    cmp_ = sub.add_parser("compare", help="diff two report JSONs into a score-delta table")
+    cmp_.add_argument("baseline", help="baseline report JSON (or a history entry)")
+    cmp_.add_argument("current", help="current report JSON")
+    cmp_.add_argument("--markdown", action="store_true", help="emit the sticky PR-comment markdown")
+    cmp_.add_argument("--fail-on-regression", action="store_true", help="exit 1 if any family regressed")
     return p
 
 
@@ -76,6 +83,8 @@ def _add_common_flags(sp: argparse.ArgumentParser) -> None:
     sp.add_argument("--snapshot-path", default=None)
     sp.add_argument("--stdio-timeout", type=float, default=None)
     sp.add_argument("--transport", choices=["auto", "stdio", "streamable-http", "sse"], default=None)
+    sp.add_argument("--record", metavar="PATH", default=None, help="append this run to a history JSONL")
+    sp.add_argument("--commit", default=None, help="commit SHA for the history entry (or $GITHUB_SHA)")
 
 
 def _add_family_flags(sp: argparse.ArgumentParser) -> None:
@@ -147,6 +156,8 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_snapshot(args)
     if args.command == "fix":
         return _cmd_fix(args)
+    if args.command == "compare":
+        return _cmd_compare(args)
     return _cmd_run(args)
 
 
@@ -175,8 +186,50 @@ def _cmd_run(args: argparse.Namespace) -> int:
         Path(config.html_out).write_text(render_html(report), encoding="utf-8")
     if config.emit_stampede:
         _write_stampede_seed(report, config.emit_stampede)
+    if getattr(args, "record", None):
+        _record_history(args, report)
 
     return int(outcome.exit_code)
+
+
+def _record_history(args: argparse.Namespace, report: Any) -> None:
+    import datetime
+    import os
+
+    from mcp_probe.history import append_history, entry_from_report
+    from mcp_probe.report import report_to_dict
+
+    commit = args.commit or os.environ.get("GITHUB_SHA", "")
+    ts = datetime.datetime.now(datetime.UTC).isoformat()
+    entry = entry_from_report(report_to_dict(report, include_meta=False), commit=commit, ts=ts)
+    append_history(args.record, entry)
+
+
+def _cmd_compare(args: argparse.Namespace) -> int:
+    import json
+
+    from mcp_probe.history import compute_delta, render_delta_markdown
+
+    baseline = json.loads(Path(args.baseline).read_text(encoding="utf-8"))
+    current = json.loads(Path(args.current).read_text(encoding="utf-8"))
+    delta = compute_delta(baseline, current)
+
+    if args.markdown:
+        print(render_delta_markdown(delta), end="")
+    else:
+        oc = delta.overall_change
+        oc_str = "→0" if oc == 0 else (f"{oc:+.0f}" if oc is not None else "n/a")
+        print(f"overall: {delta.grade_before} → {delta.grade_after} ({oc_str})")
+        if delta.rubric_mismatch:
+            print("  rubric changed — per-family comparison skipped")
+        for name, (b, a) in delta.per_family.items():
+            bs = "—" if b is None else f"{b:.0f}"
+            as_ = "—" if a is None else f"{a:.0f}"
+            print(f"  {name:12} {bs:>4} → {as_:>4}")
+
+    if args.fail_on_regression and delta.has_regression:
+        return int(ExitCode.GATE_FAILURE)
+    return int(ExitCode.OK)
 
 
 def _cmd_snapshot(args: argparse.Namespace) -> int:

--- a/src/mcp_probe/cli.py
+++ b/src/mcp_probe/cli.py
@@ -102,6 +102,8 @@ def _add_family_flags(sp: argparse.ArgumentParser) -> None:
     )
     sp.add_argument("--seed", type=int, default=None)
     sp.add_argument("--concurrency", type=int, default=None)
+    sp.add_argument("--response-bloat", action="store_true",
+                    help="sample read-only tool outputs to measure response token weight (REQ-$5)")
 
 
 def _families_from_args(args: argparse.Namespace) -> tuple[str, ...]:
@@ -132,6 +134,7 @@ def _config_from_args(args: argparse.Namespace) -> ProbeConfig:
         "deep_security": _true_or_none(getattr(args, "deep_security", False)),
         "model": getattr(args, "model", None),
         "token_model": getattr(args, "token_model", None),
+        "response_bloat": _true_or_none(getattr(args, "response_bloat", False)),
         "seed": getattr(args, "seed", None),
         "concurrency": getattr(args, "concurrency", None),
         "families": _families_from_args(args) if hasattr(args, "all_families") else None,

--- a/src/mcp_probe/config.py
+++ b/src/mcp_probe/config.py
@@ -55,6 +55,9 @@ class ProbeConfig:
     # Opt-in authoritative token counting, e.g. "anthropic:claude-sonnet-5". Needs
     # ANTHROPIC_API_KEY; silently falls back to the offline tiktoken estimate otherwise.
     token_model: str | None = None
+    # Opt-in: sample read-only tool outputs to measure response token weight (REQ-$5).
+    # Live-only; adds invocation latency, so off by default. Never affects the fast-path score.
+    response_bloat: bool = False
 
     # --- performance ([net]) ---
     concurrency: int = 50

--- a/src/mcp_probe/engines/cost.py
+++ b/src/mcp_probe/engines/cost.py
@@ -31,6 +31,10 @@ from mcp_probe.tokens import (
 TOKEN_BUDGET = 2000
 # A single tool heavier than this is flagged as bloated (REQ-$2).
 PER_TOOL_BLOAT = 700
+# Above this toolset weight, lazy-loading / Tool Search starts to pay off (REQ-$6).
+REMEDIATION_THRESHOLD = 10_000
+# A single tool response heavier than this is flagged as response-bloat (REQ-$5).
+RESPONSE_BLOAT_TOKENS = 1_000
 # Penalty curve constants, anchored to the documented landmarks (see module docstring).
 _A, _B = 10.7, 1.8
 
@@ -112,6 +116,27 @@ class CostEngine(EngineBase):
                     )
                 )
 
+        # REQ-$6: remediation hint when the toolset is heavy enough that deferring pays off.
+        if toolset_tokens > REMEDIATION_THRESHOLD:
+            deferrable = toolset_tokens - TOKEN_BUDGET
+            pct = round(100 * deferrable / toolset_tokens)
+            findings.append(
+                Finding(
+                    family=self.name,
+                    code="$6-remediation",
+                    severity=Severity.INFO,
+                    message=f"toolset is {toolset_tokens} tokens; Tool Search / lazy-loading / "
+                    f"Code Mode could defer up to ~{deferrable} tokens ({pct}%) until a tool is used",
+                    remediation="adopt MCP Tool Search or load tool defs lazily; keep only "
+                    "always-needed tools eager",
+                    evidence={"toolset_tokens": toolset_tokens, "deferrable_tokens": deferrable},
+                )
+            )
+
+        # REQ-$5: response bloat (opt-in, live). Sample read-only tool outputs and measure
+        # their token weight — the *other* half of the context tax. Never affects the score.
+        response_tokens = await self._sample_responses(ctx, counter, findings)
+
         price_points = self._resolve_price_points(ctx)
         usd_by_point = {
             label: round(toolset_tokens / 1_000_000 * price, 4)
@@ -138,6 +163,7 @@ class CostEngine(EngineBase):
             "counter": counter_name,
             "counter_note": estimate_note,
             "tools": len(tools),
+            "response_tokens": response_tokens,  # dict, or "not measured"
         }
         from mcp_probe.scoring import grade_for_score
 
@@ -148,6 +174,45 @@ class CostEngine(EngineBase):
             findings=findings,
             metrics=metrics,
         )
+
+    async def _sample_responses(
+        self, ctx: ProbeContext, counter: TokenCounter, findings: list[Finding]
+    ) -> dict[str, int] | str:
+        """Invoke read-only tools and count their response tokens (REQ-$5). Opt-in + live;
+        returns "not measured" otherwise. Read-only only — never fires a destructive tool."""
+        if not getattr(ctx.config, "response_bloat", False) or ctx.client is None:
+            return "not measured"
+        import json
+
+        from mcp_probe.contract.schema import synthesize_args
+        from mcp_probe.engines.contract import _is_write
+
+        seed = getattr(ctx.config, "seed", 42)
+        out: dict[str, int] = {}
+        for t in ctx.surface.tools:
+            if _is_write(t):
+                continue
+            try:
+                result = await ctx.client.call_tool(t.name, synthesize_args(t.input_schema, seed=seed))
+                payload = result.structured if result.structured is not None else result.content
+                tokens = counter.count(json.dumps(payload, default=str, ensure_ascii=False))
+            except Exception:
+                continue
+            out[t.name] = tokens
+            if tokens > RESPONSE_BLOAT_TOKENS:
+                findings.append(
+                    Finding(
+                        family=self.name,
+                        code="$5-response-bloat",
+                        severity=Severity.LOW,
+                        tool=t.name,
+                        message=f"tool '{t.name}' returns ~{tokens} tokens per call — a large "
+                        "response tax on top of the schema tax",
+                        remediation="paginate, summarize, or let the caller select fields",
+                        evidence={"response_tokens": tokens},
+                    )
+                )
+        return out
 
     @staticmethod
     def _authoritative_total(ctx: ProbeContext, tools: tuple[ToolDef, ...]) -> int | None:

--- a/src/mcp_probe/engines/legibility.py
+++ b/src/mcp_probe/engines/legibility.py
@@ -195,8 +195,10 @@ class LegibilityEngine(EngineBase):
             tool = surface.tool(name)
             if tool is None:
                 continue
-            rewrite = model.propose_rewrite(name, tool.description or "", confusers.get(name, []))
-            rewrites.append({"tool": name, "rewrite": rewrite})
+            old = tool.description or ""
+            rewrite = model.propose_rewrite(name, old, confusers.get(name, []))
+            # Carry the exact old text so `mcp-probe fix` can find-and-replace it safely.
+            rewrites.append({"tool": name, "rewrite": rewrite, "old": old})
         return rewrites
 
     @staticmethod
@@ -221,6 +223,8 @@ class LegibilityEngine(EngineBase):
                     tool=entry["tool"],
                     message=f"'{entry['tool']}' is hard to select; a clearer description would help",
                     remediation=f"proposed: {entry['rewrite']}",
+                    # `mcp-probe fix` consumes old/rewrite to apply the change to source (REQ-L7).
+                    evidence={"old": entry.get("old", ""), "rewrite": entry["rewrite"]},
                 )
             )
         return findings

--- a/src/mcp_probe/fix.py
+++ b/src/mcp_probe/fix.py
@@ -1,0 +1,127 @@
+"""Legibility auto-fix (REQ-L7) — apply the description rewrites mcp-probe proposes.
+
+The diagnosis→fix loop: `run --legibility` emits `L5-rewrite` findings carrying the exact
+`old` description and a proposed `rewrite` (in each finding's ``evidence``). This module
+finds the old text in a target source file and replaces it with the rewrite, safely:
+
+* **Exact-match only** — the scanned description must appear verbatim in the source, or the
+  rewrite is skipped (never a fuzzy edit).
+* **Ambiguity guard** — if the old text appears more than once, skip it (can't tell which).
+* **Dry-run by default** — callers opt in to writing; opening a PR is a further opt-in.
+
+Servers that build descriptions dynamically won't match; that's reported, not forced.
+"""
+
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Rewrite:
+    tool: str
+    old: str
+    new: str
+
+
+@dataclass
+class ApplyResult:
+    applied: list[Rewrite] = field(default_factory=list)
+    skipped: list[tuple[Rewrite, str]] = field(default_factory=list)  # (rewrite, reason)
+    diff: str = ""
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.applied)
+
+
+def collect_rewrites(report: dict[str, Any], *, only: set[str] | None = None) -> list[Rewrite]:
+    """Pull (tool, old, new) rewrites out of a report's legibility L5-rewrite findings."""
+    leg = report.get("families", {}).get("legibility", {})
+    out: list[Rewrite] = []
+    for f in leg.get("findings", []):
+        if f.get("code") != "L5-rewrite":
+            continue
+        ev = f.get("evidence") or {}
+        old, new = ev.get("old"), ev.get("rewrite")
+        tool = f.get("tool")
+        if not old or not new or not tool:
+            continue  # nothing safely applicable (e.g. an empty original description)
+        if only is not None and tool not in only:
+            continue
+        out.append(Rewrite(tool=tool, old=old, new=new))
+    return out
+
+
+def _occurrences(text: str, needle: str) -> list[int]:
+    idx, out = text.find(needle), []
+    while idx != -1:
+        out.append(idx)
+        idx = text.find(needle, idx + 1)
+    return out
+
+
+def _locate(text: str, rw: Rewrite) -> tuple[int | None, str]:
+    """Return (start_index, reason). When the old text repeats, pick the occurrence
+    *nearest* the tool's name (decorator-style servers put them adjacent); a tie is
+    ambiguous and skipped. Sequential application also helps: once one identical
+    description is rewritten, the next becomes unique."""
+    occ = _occurrences(text, rw.old)
+    if not occ:
+        return None, "original description not found in source (dynamic?)"
+    if len(occ) == 1:
+        return occ[0], ""
+    tool_pos = _occurrences(text, rw.tool)
+    if not tool_pos:
+        return None, f"original appears {len(occ)}× and tool name '{rw.tool}' not in source — skipped"
+
+    def nearest(i: int) -> int:
+        return min(abs(i - tp) for tp in tool_pos)
+
+    ranked = sorted(occ, key=nearest)
+    if len(ranked) >= 2 and nearest(ranked[0]) == nearest(ranked[1]):
+        return None, f"original appears {len(occ)}× and can't be anchored to '{rw.tool}' — skipped"
+    return ranked[0], ""
+
+
+def apply_rewrites(source: str, rewrites: list[Rewrite]) -> tuple[str, ApplyResult]:
+    """Apply rewrites to ``source`` text. Returns (new_source, result). Pure — no I/O.
+
+    Replacement is index-based and re-scans after each edit, so shifting offsets are
+    handled and repeated descriptions are disambiguated by tool-name proximity."""
+    result = ApplyResult()
+    updated = source
+    for rw in rewrites:
+        if rw.old == rw.new:
+            result.skipped.append((rw, "rewrite identical to original"))
+            continue
+        start, reason = _locate(updated, rw)
+        if start is None:
+            result.skipped.append((rw, reason))
+            continue
+        updated = updated[:start] + rw.new + updated[start + len(rw.old):]
+        result.applied.append(rw)
+
+    if result.applied:
+        result.diff = "".join(
+            difflib.unified_diff(
+                source.splitlines(keepends=True),
+                updated.splitlines(keepends=True),
+                fromfile="a/source",
+                tofile="b/source",
+            )
+        )
+    return updated, result
+
+
+def apply_to_file(path: str | Path, rewrites: list[Rewrite], *, write: bool) -> ApplyResult:
+    """Apply rewrites to a file. ``write=False`` computes the diff without touching disk."""
+    p = Path(path)
+    source = p.read_text(encoding="utf-8")
+    updated, result = apply_rewrites(source, rewrites)
+    if write and result.changed:
+        p.write_text(updated, encoding="utf-8")
+    return result

--- a/src/mcp_probe/history.py
+++ b/src/mcp_probe/history.py
@@ -1,0 +1,146 @@
+"""Historical score tracking + PR score-delta rendering (issue #9).
+
+The gate says pass/fail; history says which *direction* you're trending. Each run can be
+appended to ``.mcp-probe/history.jsonl`` (one JSON object per line), and any two reports
+can be diffed into a per-family delta table — rendered for the terminal or as a sticky PR
+comment. Cross-rubric comparison is refused (scores minted under different rubrics aren't
+comparable, same rule as snapshot diffing / NFR-7).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from mcp_probe.scoring.scorer import _GRADE_ORDER
+
+# Sticky marker so a CI bot can find-and-update its own PR comment instead of spamming.
+COMMENT_MARKER = "<!-- mcp-probe-score-delta -->"
+
+
+def entry_from_report(report: dict[str, Any], *, commit: str = "", ts: str = "") -> dict[str, Any]:
+    """Project a report dict down to a compact history entry."""
+    fams = {
+        name: fam.get("score")
+        for name, fam in report.get("families", {}).items()
+        if fam.get("score") is not None
+    }
+    return {
+        "commit": commit,
+        "ts": ts,
+        "rubric_version": report.get("rubric_version", ""),
+        "overall_score": report.get("overall", {}).get("score"),
+        "overall_grade": report.get("overall", {}).get("grade"),
+        "surface_hash": report.get("target", {}).get("surface_hash", ""),
+        "families": fams,
+    }
+
+
+def append_history(path: str | Path, entry: dict[str, Any]) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def load_history(path: str | Path) -> list[dict[str, Any]]:
+    p = Path(path)
+    if not p.is_file():
+        return []
+    return [json.loads(line) for line in p.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+@dataclass
+class ScoreDelta:
+    overall_before: float | None
+    overall_after: float | None
+    grade_before: str
+    grade_after: str
+    per_family: dict[str, tuple[float | None, float | None]] = field(default_factory=dict)
+    rubric_mismatch: bool = False
+
+    @property
+    def overall_change(self) -> float | None:
+        if self.overall_before is None or self.overall_after is None:
+            return None
+        return round(self.overall_after - self.overall_before, 1)
+
+    @property
+    def grade_dropped(self) -> bool:
+        return _GRADE_ORDER.get(self.grade_after, 0) < _GRADE_ORDER.get(self.grade_before, 0)
+
+    @property
+    def has_regression(self) -> bool:
+        if self.grade_dropped:
+            return True
+        return any(
+            b is not None and a is not None and a < b - 0.05
+            for b, a in self.per_family.values()
+        )
+
+
+def compute_delta(baseline: dict[str, Any], current: dict[str, Any]) -> ScoreDelta:
+    """Diff two report dicts (or history entries): baseline → current."""
+    b_over = _overall(baseline)
+    c_over = _overall(current)
+    delta = ScoreDelta(
+        overall_before=b_over[0],
+        overall_after=c_over[0],
+        grade_before=b_over[1],
+        grade_after=c_over[1],
+        rubric_mismatch=baseline.get("rubric_version") != current.get("rubric_version"),
+    )
+    if delta.rubric_mismatch:
+        return delta  # refuse per-family comparison across rubrics
+    b_fams, c_fams = _families(baseline), _families(current)
+    for name in sorted(set(b_fams) | set(c_fams)):
+        delta.per_family[name] = (b_fams.get(name), c_fams.get(name))
+    return delta
+
+
+def _overall(doc: dict[str, Any]) -> tuple[float | None, str]:
+    if "overall" in doc:  # a report dict
+        return doc["overall"].get("score"), doc["overall"].get("grade", "?")
+    return doc.get("overall_score"), doc.get("overall_grade", "?")  # a history entry
+
+
+def _families(doc: dict[str, Any]) -> dict[str, float]:
+    if "families" in doc and doc["families"] and isinstance(next(iter(doc["families"].values())), dict):
+        return {n: f["score"] for n, f in doc["families"].items() if f.get("score") is not None}
+    return {n: s for n, s in doc.get("families", {}).items() if s is not None}  # history entry
+
+
+def _arrow(before: float | None, after: float | None) -> str:
+    if before is None or after is None:
+        return "·"
+    d = after - before
+    if abs(d) < 0.05:
+        return "→ 0"
+    return f"{'▲' if d > 0 else '▼'} {d:+.0f}"
+
+
+def render_delta_markdown(delta: ScoreDelta) -> str:
+    """The sticky PR comment body."""
+    lines = [COMMENT_MARKER, "### MCP Quality Score — change vs base", ""]
+    if delta.rubric_mismatch:
+        lines.append("⚠️ Rubric version changed vs base — scores are not comparable.")
+        return "\n".join(lines) + "\n"
+    oc = delta.overall_change
+    oc_str = "→ 0" if oc == 0 else (f"{oc:+.0f}" if oc is not None else "n/a")
+    lines += [
+        f"**Overall:** {delta.grade_before} → **{delta.grade_after}** ({oc_str})"
+        + ("  ⚠️ **regression**" if delta.has_regression else ""),
+        "",
+        "| Family | Base | PR | Δ |",
+        "|--------|------|----|---|",
+    ]
+    for name, (b, a) in delta.per_family.items():
+        lines.append(
+            f"| {name.capitalize()} | {b:.0f} | {a:.0f} | {_arrow(b, a)} |"
+            if b is not None and a is not None
+            else f"| {name.capitalize()} | {'—' if b is None else f'{b:.0f}'} "
+            f"| {'—' if a is None else f'{a:.0f}'} | · |"
+        )
+    return "\n".join(lines) + "\n"

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -91,3 +91,55 @@ async def test_falls_back_to_estimate_when_authoritative_unavailable(monkeypatch
     fs = await cost_mod.CostEngine(counter=HeuristicCounter()).run(ctx)
     assert fs.metrics["counter"] == "heuristic"
     assert "estimate" in fs.metrics["counter_note"]
+
+
+async def test_remediation_hint_on_heavy_toolset():
+    # A big toolset should emit the $6 lazy-loading hint with a projected saving (REQ-$6).
+    tools = [
+        {"name": f"t{i}", "description": "word " * 200, "inputSchema": {"type": "object"}}
+        for i in range(40)
+    ]
+    from mcp_probe.engines.cost import CostEngine
+
+    fs = await CostEngine(counter=HeuristicCounter()).run(make_ctx(tools))
+    hint = next((f for f in fs.findings if f.code == "$6-remediation"), None)
+    assert hint is not None
+    assert hint.evidence["deferrable_tokens"] > 0
+    assert "Tool Search" in hint.message
+
+
+async def test_no_remediation_hint_on_lean_toolset():
+    tools = [{"name": "get_x", "description": "Return x.", "inputSchema": {"type": "object"}}]
+    from mcp_probe.engines.cost import CostEngine
+
+    fs = await CostEngine(counter=HeuristicCounter()).run(make_ctx(tools))
+    assert not any(f.code == "$6-remediation" for f in fs.findings)
+
+
+async def test_response_bloat_not_measured_by_default():
+    tools = [{"name": "get_x", "description": "Return x.", "inputSchema": {"type": "object"}}]
+    from mcp_probe.engines.cost import CostEngine
+
+    fs = await CostEngine(counter=HeuristicCounter()).run(make_ctx(tools))
+    assert fs.metrics["response_tokens"] == "not measured"
+
+
+async def test_response_bloat_sampled_when_opted_in():
+    from mcp_probe.connect.client import FakeClient, InvokeResult
+    from mcp_probe.engines.cost import CostEngine
+
+    tools = [
+        {"name": "get_small", "description": "read", "inputSchema": {"type": "object"},
+         "annotations": {"readOnlyHint": True}},
+        {"name": "get_big", "description": "read", "inputSchema": {"type": "object"},
+         "annotations": {"readOnlyHint": True}},
+    ]
+    client = FakeClient(results={
+        "get_small": InvokeResult("get_small", False, content={"ok": 1}),
+        "get_big": InvokeResult("get_big", False, content=[], structured={"rows": ["word " * 400] * 5}),
+    })
+    ctx = make_ctx(tools, client=client, config=ProbeConfig(response_bloat=True))
+    fs = await CostEngine(counter=HeuristicCounter()).run(ctx)
+    rt = fs.metrics["response_tokens"]
+    assert isinstance(rt, dict) and rt["get_big"] > rt["get_small"]
+    assert any(f.code == "$5-response-bloat" and f.tool == "get_big" for f in fs.findings)

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -1,0 +1,105 @@
+"""Legibility auto-fix tests (REQ-L7, issue #8) — collect + apply rewrites, incl. the
+name-anchoring that resolves identical descriptions, and an e2e through the CLI."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from mcp_probe.cli import main
+from mcp_probe.fix import Rewrite, apply_rewrites, collect_rewrites
+
+SERVERS = Path(__file__).parent / "servers"
+
+
+def _report_with_rewrites(entries: list[dict]) -> dict:
+    return {
+        "families": {
+            "legibility": {
+                "findings": [
+                    {"code": "L5-rewrite", "tool": e["tool"],
+                     "evidence": {"old": e["old"], "rewrite": e["new"]}}
+                    for e in entries
+                ]
+            }
+        }
+    }
+
+
+def test_collect_rewrites_pulls_old_and_new():
+    report = _report_with_rewrites([{"tool": "t", "old": "Old.", "new": "New, clearer."}])
+    rws = collect_rewrites(report)
+    assert rws == [Rewrite(tool="t", old="Old.", new="New, clearer.")]
+
+
+def test_collect_rewrites_respects_accept_filter():
+    report = _report_with_rewrites([
+        {"tool": "a", "old": "A", "new": "AA"},
+        {"tool": "b", "old": "B", "new": "BB"},
+    ])
+    assert [r.tool for r in collect_rewrites(report, only={"b"})] == ["b"]
+
+
+def test_apply_exact_single_match():
+    src = 'description="Old text here."\n'
+    out, res = apply_rewrites(src, [Rewrite("t", "Old text here.", "New text.")])
+    assert "New text." in out and "Old text here." not in out
+    assert res.applied and not res.skipped
+
+
+def test_apply_skips_when_not_found():
+    _out, res = apply_rewrites("nothing matches", [Rewrite("t", "absent", "x")])
+    assert not res.applied
+    assert "not found" in res.skipped[0][1]
+
+
+def test_apply_name_anchors_identical_descriptions():
+    # Both tools share the same description string — the confusable case. Anchoring by the
+    # tool name must send each rewrite to the right occurrence.
+    src = (
+        'def delete_record():\n    description="Remove a record by id."\n\n'
+        'def archive_record():\n    description="Remove a record by id."\n'
+    )
+    rws = [
+        Rewrite("delete_record", "Remove a record by id.", "Permanently delete a record by id."),
+        Rewrite("archive_record", "Remove a record by id.", "Move a record to the archive."),
+    ]
+    out, res = apply_rewrites(src, rws)
+    assert len(res.applied) == 2
+    # each rewrite landed next to its own function
+    assert "def delete_record():\n    description=\"Permanently delete a record by id.\"" in out
+    assert "def archive_record():\n    description=\"Move a record to the archive.\"" in out
+
+
+def test_cli_fix_apply_changes_confusable_server(tmp_path):
+    # e2e: apply real rewrites to a copy of the confusable fixture via the CLI.
+    src = tmp_path / "confusable_server.py"
+    shutil.copy(SERVERS / "confusable_server.py", src)
+    report = tmp_path / "report.json"
+    report.write_text(json.dumps(_report_with_rewrites([
+        {"tool": "delete_record", "old": "Remove a record by id.",
+         "new": "Permanently delete a record by id (cannot be undone)."},
+        {"tool": "archive_record", "old": "Remove a record by id.",
+         "new": "Move a record to the archive; reversible."},
+    ])), encoding="utf-8")
+
+    rc = main(["fix", "--from", str(report), "--source", str(src), "--apply"])
+    assert rc == 0
+    text = src.read_text(encoding="utf-8")
+    assert "Permanently delete a record by id" in text
+    assert "Move a record to the archive" in text
+    assert "Remove a record by id." not in text  # both originals rewritten
+
+
+def test_cli_fix_dry_run_does_not_write(tmp_path):
+    src = tmp_path / "s.py"
+    src.write_text('description="Remove a record by id."\n', encoding="utf-8")
+    report = tmp_path / "r.json"
+    report.write_text(json.dumps(_report_with_rewrites([
+        {"tool": "delete_record", "old": "Remove a record by id.", "new": "Delete it."},
+    ])), encoding="utf-8")
+    before = src.read_text(encoding="utf-8")
+    rc = main(["fix", "--from", str(report), "--source", str(src)])  # no --apply
+    assert rc == 0
+    assert src.read_text(encoding="utf-8") == before  # unchanged

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,91 @@
+"""History + score-delta tests (issue #9) — delta math, rubric guard, sticky markdown,
+append/load, and the CLI `compare` + `run --record` surfaces."""
+
+from __future__ import annotations
+
+import json
+
+from mcp_probe.cli import main
+from mcp_probe.history import (
+    COMMENT_MARKER,
+    append_history,
+    compute_delta,
+    entry_from_report,
+    load_history,
+    render_delta_markdown,
+)
+
+
+def _report(overall, grade, fams, rubric="2026.07.1"):
+    return {
+        "rubric_version": rubric,
+        "overall": {"score": overall, "grade": grade},
+        "target": {"surface_hash": "sha256:abc"},
+        "families": {n: {"score": s, "grade": "?"} for n, s in fams.items()},
+    }
+
+
+def test_compute_delta_math():
+    base = _report(80, "B", {"cost": 90, "contract": 70})
+    cur = _report(75, "C", {"cost": 85, "contract": 65})
+    d = compute_delta(base, cur)
+    assert d.overall_change == -5.0
+    assert d.grade_dropped is True
+    assert d.per_family["cost"] == (90, 85)
+    assert d.has_regression is True
+
+
+def test_no_regression_when_flat_or_up():
+    base = _report(80, "B", {"cost": 80})
+    cur = _report(82, "B", {"cost": 82})
+    d = compute_delta(base, cur)
+    assert d.has_regression is False
+
+
+def test_rubric_mismatch_refuses_family_diff():
+    base = _report(80, "B", {"cost": 80}, rubric="1999.01.0")
+    cur = _report(20, "F", {"cost": 20}, rubric="2026.07.1")
+    d = compute_delta(base, cur)
+    assert d.rubric_mismatch is True
+    assert d.per_family == {}
+
+
+def test_markdown_has_marker_and_table():
+    base = _report(80, "B", {"cost": 90})
+    cur = _report(70, "C", {"cost": 70})
+    md = render_delta_markdown(compute_delta(base, cur))
+    assert md.startswith(COMMENT_MARKER)
+    assert "regression" in md
+    assert "| Family | Base | PR | Δ |" in md
+
+
+def test_history_roundtrip(tmp_path):
+    path = tmp_path / "history.jsonl"
+    entry = entry_from_report(_report(90, "A", {"cost": 90}), commit="abc123", ts="2026-01-01T00:00:00Z")
+    append_history(path, entry)
+    append_history(path, entry_from_report(_report(85, "B", {"cost": 85}), commit="def456"))
+    hist = load_history(path)
+    assert len(hist) == 2
+    assert hist[0]["commit"] == "abc123"
+    assert hist[0]["overall_grade"] == "A"
+
+
+def test_cli_compare_markdown(tmp_path, capsys):
+    base = tmp_path / "base.json"
+    cur = tmp_path / "cur.json"
+    base.write_text(json.dumps(_report(80, "B", {"cost": 90})), encoding="utf-8")
+    cur.write_text(json.dumps(_report(70, "C", {"cost": 70})), encoding="utf-8")
+    rc = main(["compare", str(base), str(cur), "--markdown"])
+    assert rc == 0
+    assert COMMENT_MARKER in capsys.readouterr().out
+
+
+def test_cli_compare_fail_on_regression(tmp_path):
+    base = tmp_path / "base.json"
+    cur = tmp_path / "cur.json"
+    base.write_text(json.dumps(_report(80, "B", {"cost": 90})), encoding="utf-8")
+    cur.write_text(json.dumps(_report(60, "D", {"cost": 60})), encoding="utf-8")
+    assert main(["compare", str(base), str(cur), "--fail-on-regression"]) == 1
+    # and passes (exit 0) when improved
+    cur.write_text(json.dumps(_report(95, "A", {"cost": 95})), encoding="utf-8")
+    assert main(["compare", str(base), str(cur), "--fail-on-regression"]) == 0


### PR DESCRIPTION
Closes #11 (REQ-$5/$6). Extends Cost from "what the schema costs" to "what the responses cost", and turns bloat into an actionable hint.

## What
- **$6 remediation hint** `[fast]`: when the toolset exceeds ~10k tokens, emit a hint to adopt Tool Search / lazy-loading / Code Mode with a **projected deferrable-token saving** (computed from the toolset weight above the lean budget).
- **$5 response-bloat** `[net, opt-in]`: `--response-bloat` samples each **read-only** tool's output (synthesized args, never a destructive tool) and measures its response token weight — the other half of the context tax. Large responses get a `$5-response-bloat` finding. Live-only; reported "not measured" otherwise and **never affects the deterministic score** (NFR-2 preserved).

## e2e verified
- Component tests: $6 fires on a heavy toolset / stays silent on a lean one; $5 sampled via a scripted client, big response flagged, "not measured" by default.
- **Live**: `mcp-probe run bloated_server --response-bloat` sampled real responses from all 30 tools. Full suite **116 passing**, ruff + mypy clean.

## Stack
#11, on top of #9 (`feat/v0.2-09-history`). Merge order: #8 → #9 → #11.