### PR TITLE
feat: hardening — HTTP auth headers, --fail-under-family, real-scanner test (closes #14)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Current state: v0.1 implemented (all five families)
+
+The v0.1 fast path and all five check families are implemented, tested, and dogfooded.
+Python 3.11+ (`src/` layout, `pip install`), official MCP SDK, `asyncio`. What deviates
+from the spec is recorded in **`docs/DECISIONS.md`** — read it before changing security
+IDs, the handshake, or the token counter.
+
+### Commands
+
+```bash
+python -m venv .venv && .venv/bin/pip install -e ".[dev]"   # setup
+
+.venv/bin/pytest -m "not live_llm" -q            # full suite (unit+component+integration+e2e)
+.venv/bin/pytest tests/test_scorer.py -q          # a single test file
+.venv/bin/pytest -m e2e -q                        # only the live-fixture E2E scenarios
+.venv/bin/pytest -m live_llm -q                   # opt-in, calls a real model (excluded by default)
+.venv/bin/ruff check src/ tests/                  # lint (line-length 110)
+.venv/bin/mypy src/                               # types (strict)
+
+.venv/bin/mcp-probe run ".venv/bin/python tests/servers/good_server.py"   # live probe
+.venv/bin/mcp-probe static tests/servers/dump.mcp.json --json             # offline
+.venv/bin/mcp-probe run "…" --all --model ollama:qwen2.5-3b               # all five families
+```
+
+Tests spawn fixture servers with the **same interpreter running pytest** (`sys.executable`),
+so they need the SDK installed in that env — always run via `.venv/bin/pytest`.
+
+### Package layout (`src/mcp_probe/`)
+
+- `models.py` — the frozen data model (`ServerSurface`/`Finding`/`FamilyScore`/`Report`/`CheckEngine`).
+- `config.py` · `cli.py` · `exit_codes.py` — config precedence, the 4 subcommands, CI exit codes.
+- `connect/` — `transport.py` is the **only** module importing the MCP SDK; `client.py` is the
+  façade + `FakeClient`; `discover.py` builds surfaces (live + static dump).
+- `engines/` — one file per family, each a pure `CheckEngine`; registered in `engines/__init__.py`.
+- `contract/`, `legibility/`, `security/`, `perf/`, `tokens.py` — engine-specific internals.
+- `scoring/` · `snapshot/` · `report/` · `handoff.py` · `trace.py` — aggregation & outputs.
+- `tests/servers/` — fixture MCP servers (the TEST-PLAN §2 matrix) + `dump.mcp.json`.
+
+## What mcp-probe is
+
+The **CI quality suite for MCP servers** — "the `pytest` + `lighthouse` for the servers agents depend on." It connects to an MCP server, discovers its surface, and grades it across **five check families** into a single A–F **MCP Quality Score**, designed to run as a CI gate with a README badge.
+
+Positioning is load-bearing and deliberate: security scanners (mcp-scan, Cisco) answer *"is this server dangerous?"*; mcp-probe answers *"is this server good?"* It treats security as **one light check**, defers deep security to the incumbents via `--deep-security` integration (never reimplements them), and unifies the quality *point* tools (credits mcp-xray as prior art) into a CI-native **suite and gate**. Do not drift the messaging toward "another scanner."
+
+The five families: **Contract** (LLM-free spec/schema/determinism), **Legibility** (the differentiator — agent-comprehension score + disambiguation matrix), **Cost** (toolset token weight), **Performance** (concurrent MCP-semantic load), **Security-lite** (OWASP MCP Top 10 basics + integration adapter).
+
+## Documentation hierarchy (read in this order)
+
+The docs are authoritative and layered — consult them before implementing anything:
+
+1. **`SPEC.md`** — the frozen v1.0 design spec/PRD. The baseline.
+2. **`docs/PRD.md`** — numbered, testable requirements: `REQ-*` (functional, per family) and `NFR-*` (non-functional). This is the requirement-of-record; code and tests reference these IDs.
+3. **`docs/ARCHITECTURE.md`** — system design, the core data model (`ServerSurface`, `Finding`, `FamilyScore`, `Report`, `CheckEngine`), the JSON output schema, and the **ADRs** (ADR-001..009) that bind implementation choices.
+4. **`docs/DELIVERY-PLAN.md`** — the WBS (`W0..W6`), effort sizing, critical path, and v0.1 Definition of Done.
+5. **`docs/TEST-PLAN.md`** — the acceptance backbone: E2E scenarios (`E2E-1..10`), the fixture server matrix, the `StubModel` determinism harness, and CI gates.
+6. **`docs/RESEARCH.md`** — the competitive/market analysis the positioning rests on.
+
+**Conventions in the docs that carry into code:**
+- The **`⊕ Beyond original spec`** marker flags anything extending the frozen v1.0 `SPEC.md`. Preserve it when editing docs; it tracks scope past the baseline.
+- Requirement IDs (`REQ-C4`, `NFR-2`, etc.) and finding codes (`C5-nondeterminism`, `S1-owasp-mcp05`) are stable identifiers — reference them in commits, tests, and `Finding.code`.
+- Tier labels: **[fast]** = zero-LLM deterministic, **[llm]** = needs a small model, **[net]** = needs a live server, **[static-ok]** = works offline in `static` mode.
+
+## Architecture: the binding decisions
+
+The system is a **pipeline**: `connect → discover → fan out to five engines → Scorer → Renderer/JSON/badge`. When implementing, these ADRs are constraints, not suggestions:
+
+- **ADR-001 — Engines are pure functions of `ServerSurface` (+ optional live client) → `FamilyScore`.** No engine mutates shared state; the Scorer and Renderer are the *only* aggregators. This is what makes the fast path deterministic and every engine testable with a fixed `ServerSurface` and no network/LLM. Adding a sixth family = implement the `CheckEngine` protocol and register it. **Smuggling shared mutable state into an engine violates the architecture.**
+- **ADR-002 — Zero-LLM fast path is the CI default.** Contract + Cost + Performance run with no model calls (`NFR-1`); Legibility is opt-in and off the critical path. The gate must be satisfiable by the fast path alone.
+- **ADR-003 — Version-aware connect.** The MCP spec is mid-transition (2025-11-25 legacy `initialize` handshake ↔ 2026-07-28 `server/discover` + `_meta`). Negotiate both, grade the result, require neither. This is the hardest correctness surface.
+- **ADR-004 — Canonical Legibility scorer = pinned local model, temp 0, fixed seed, cached by `(surface_hash, model_id, seed, goal_set_version)`.** Cloud models are opt-in and marked non-canonical. A rerun on an unchanged surface is a cache hit → ~$0, byte-identical.
+- **ADR-005 — `--deep-security` shells out and normalizes; never reimplements scanners.** Missing scanner → "not measured", never a failure.
+- **ADR-006 — `static` mode reports live-only checks as "not measured", never `0`.** Zeroing unmeasured checks is a bug (it punishes offline use and is gameable).
+- **ADR-009 — Read-only by default** (`NFR-9`); destructive tools (destructiveHint / heuristic) are skipped unless `--allow-writes`. Probing a `delete_*` tool must not fire it.
+
+### Determinism doctrine (the whole value prop)
+
+The tool grades code in CI, so its own output must be trustworthy:
+- **Fast path** (Contract/Cost/Security-lite built-in): **byte-identical** output for identical input, enforced by golden-file tests. No wall-clock or network-order dependence in scoring.
+- **Legibility**: deterministic only *under a fixed (model, seed, goal-set)*; tests use `StubModel` (never a real LLM) and assert the cache serves reruns with `call_count == 0`.
+- **Performance latencies**: inherently nondeterministic → assert *invariants* (percentile ordering `p50≤p95≤p99`, leak detection, degradation classification), never absolute ms.
+
+### Scoring rubric
+
+Weighted mean of five 0–100 sub-scores → letter grade. Default weights: **Cost 30%, Legibility 25%, Contract 20%, Performance 15%, Security-lite 10%** (see `docs/PRD.md` §7 for rationale). A family scoring **F caps overall at C** (the "hard-gate" — no A-grade server with a broken contract or critical security finding). Every report and badge carries `rubric_version` for cross-release comparability (`NFR-7`).
+
+### Shared primitives (vendored, bound to stampede's contracts)
+
+mcp-probe is project #3 of the seven-project **Swarm Proof** toolkit and reuses four primitives. The portfolio decision is **vendor-first**: copy minimal versions now rather than wait on extraction (~stampede v0.2). But the *contracts* are authoritative and must not be forked:
+- **concurrency-core** — the Performance load driver imports stampede's `Scheduler`/`Executor` **Protocol** and supplies uniform MCP-client tasks (not persona logic).
+- **report-renderer** — render via the shared `RunReport` model (oxblood style); register a `QualityScoreReport` view over it.
+- **trace-format** — **the OpenTelemetry GenAI semantic-conventions *profile*** (`gen_ai.*` spans + the `swarmproof.*` extension), *not* a bespoke schema. The `stampede --from-probe` handoff depends on cross-tool trace compatibility — consume the profile, don't fork it.
+- **persona-pack** — one minimal `naive` persona (`apiVersion: swarmproof.dev/persona/v1`) for the Legibility probe.
+
+## Working conventions
+
+- **Commits:** [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`), atomic, imperative mood, no AI attribution/signatures. Commit progressively as you go.
+- **Testability first:** because engines are pure functions, prefer a component test that feeds a fixed `ServerSurface` and asserts an exact `FamilyScore` over any test that needs a network or a real model. Live/LLM behavior belongs in integration/E2E with fakes (`StubModel`) or the opt-in, network-gated `-m live_llm` suite (excluded from the default/PR run).
+- **Dogfood:** the intended CI runs `mcp-probe` against its own `tests/servers/` fixtures — the tool must grade its own sample servers correctly (see `docs/TEST-PLAN.md` §9).
+- **Honest over impressive:** document boundaries; never zero an unmeasured check; mark non-canonical scores as such.

--- a/docs/examples/score-delta-workflow.yml
+++ b/docs/examples/score-delta-workflow.yml
@@ -1,0 +1,50 @@
+# Example: post a sticky "MCP Quality Score change" comment on every PR.
+# Copy to .github/workflows/ in your MCP server repo and set MCP_TARGET.
+# Scores the base and the PR head, diffs them, and updates one comment in place.
+name: MCP Quality delta
+on: pull_request
+
+permissions:
+  contents: read
+  pull-requests: write   # to post/update the comment
+
+env:
+  MCP_TARGET: "python my_server.py"   # <-- your server's launch command
+
+jobs:
+  score-delta:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mcp-probe
+
+      - name: Score PR head
+        run: mcp-probe run "$MCP_TARGET" --json > head.json
+
+      - name: Score base
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }} -- . || git checkout ${{ github.event.pull_request.base.sha }}
+          mcp-probe run "$MCP_TARGET" --json > base.json
+          git checkout ${{ github.sha }} -- . 2>/dev/null || true
+
+      - name: Build the delta comment
+        run: mcp-probe compare base.json head.json --markdown > delta.md
+
+      - name: Post or update the sticky comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          # find our previous comment by its hidden marker, edit it if present else create
+          id=$(gh api "repos/${{ github.repository }}/issues/$PR/comments" \
+                 --jq '.[] | select(.body | contains("<!-- mcp-probe-score-delta -->")) | .id' | head -1)
+          if [ -n "$id" ]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$id" -F body=@delta.md
+          else
+            gh pr comment "$PR" --body-file delta.md
+          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ markers = [
     "live_llm: tests that call a real LLM provider (opt-in, network-gated)",
     "e2e: end-to-end tests against fixture MCP servers",
     "integration: cross-component / transport tests",
+    "deep_security: tests that shell out to a real installed scanner (opt-in, tool-gated)",
 ]
 filterwarnings = ["error::DeprecationWarning"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ classifiers = [
 # Core deps kept lean: the zero-LLM fast path (Contract + Cost) must install and run
 # without any model provider or heavy optional tooling (NFR-1, NFR-5).
 dependencies = [
-    "mcp>=1.0",              # official MCP SDK (client transports + ClientSession)
+    "mcp>=1.28,<2",          # official MCP SDK. Pinned to v1.x: v2 renamed FastMCP→MCPServer
+                             # and changed result field casing (isError→is_error). Migration
+                             # to v2 is tracked as its own issue.
     "jsonschema>=4.21",      # Contract: input/output schema validation (REQ-C3, REQ-C4)
     "tiktoken>=0.7",         # Cost: deterministic offline token counting (REQ-$4)
     "rich>=13.7",            # terminal report renderer (oxblood theme)

--- a/scripts/leaderboard.py
+++ b/scripts/leaderboard.py
@@ -68,14 +68,19 @@ class Row:
     families: dict = field(default_factory=dict)
 
 
-async def probe_one(spec: ServerSpec, *, families: tuple[str, ...], model: str | None) -> Row:
+async def probe_one(
+    spec: ServerSpec, *, families: tuple[str, ...], model: str | None,
+    headers: dict[str, str] | None = None,
+) -> Row:
     row = Row(spec=spec)
     start = time.monotonic()
+    is_url = spec.command.strip().startswith(("http://", "https://"))
     cfg = ProbeConfig(
         target=spec.command,
-        transport="stdio",
+        transport="auto" if is_url else "stdio",
         families=families,
         model=model,
+        headers=headers or {},  # optional auth for HTTP servers
         stdio_timeout=150.0,  # npx/uvx first-run downloads can be slow
         concurrency=8,
     )
@@ -159,8 +164,16 @@ async def main() -> int:
     parser.add_argument("--legibility", action="store_true", help="add legibility via Ollama")
     parser.add_argument("--model", default="ollama:mistral-small:latest")
     parser.add_argument("--only", default="", help="comma-separated server keys to run")
+    parser.add_argument("--header", dest="headers", action="append", default=None,
+                        help="HTTP header for authed servers (repeatable), 'K: V'")
     parser.add_argument("--out", default="docs/leaderboard.md")
     args = parser.parse_args()
+
+    headers: dict[str, str] = {}
+    for h in args.headers or []:
+        k, sep, v = h.partition(":")
+        if sep:
+            headers[k.strip()] = v.strip()
 
     families = ("contract", "cost", "security")
     model = None
@@ -176,7 +189,7 @@ async def main() -> int:
     rows: list[Row] = []
     for spec in specs:  # sequential: parallel npx downloads thrash disk/network
         print(f"probing {spec.label} …", file=sys.stderr)
-        row = await probe_one(spec, families=families, model=model)
+        row = await probe_one(spec, families=families, model=model, headers=headers or None)
         if row.error:
             status = row.error
         elif row.score is not None:

--- a/src/mcp_probe/cli.py
+++ b/src/mcp_probe/cli.py
@@ -76,7 +76,11 @@ def build_parser() -> argparse.ArgumentParser:
 def _add_common_flags(sp: argparse.ArgumentParser) -> None:
     sp.add_argument("--json", dest="json_out", action="store_true", help="emit the CI JSON report")
     sp.add_argument("--fail-under", metavar="GRADE", help="exit 1 if overall grade < GRADE (A–F)")
+    sp.add_argument("--fail-under-family", metavar="F:G,...", default=None,
+                    help="per-family gates, e.g. 'Contract:A,Security:B'")
     sp.add_argument("--no-regressions", action="store_true", help="exit 1 on any regression vs snapshot")
+    sp.add_argument("--header", dest="headers", action="append", metavar="'K: V'", default=None,
+                    help="HTTP/SSE header (repeatable), e.g. --header 'Authorization: Bearer …'")
     sp.add_argument("--allow-writes", action="store_true", help="permit invoking destructive tools")
     sp.add_argument("--html", dest="html_out", metavar="PATH", help="write an HTML report")
     sp.add_argument("--emit-stampede", metavar="PATH", help="write the stampede --from-probe seed")
@@ -123,6 +127,8 @@ def _families_from_args(args: argparse.Namespace) -> tuple[str, ...]:
 def _config_from_args(args: argparse.Namespace) -> ProbeConfig:
     overrides: dict[str, Any] = {
         "fail_under": getattr(args, "fail_under", None),
+        "fail_under_family": _parse_family_gates(getattr(args, "fail_under_family", None)),
+        "headers": _parse_headers(getattr(args, "headers", None)),
         "no_regressions": _true_or_none(getattr(args, "no_regressions", False)),
         "allow_writes": _true_or_none(getattr(args, "allow_writes", False)),
         "json_out": _true_or_none(getattr(args, "json_out", False)),
@@ -149,6 +155,30 @@ def _config_from_args(args: argparse.Namespace) -> ProbeConfig:
 def _true_or_none(flag: bool) -> bool | None:
     """Store-true flags default False; treat False as 'unset' so config/env can win."""
     return True if flag else None
+
+
+def _parse_headers(raw: list[str] | None) -> dict[str, str] | None:
+    """Parse repeated ``--header 'K: V'`` into a dict (None if unset → don't override)."""
+    if not raw:
+        return None
+    out: dict[str, str] = {}
+    for item in raw:
+        key, sep, value = item.partition(":")
+        if sep:
+            out[key.strip()] = value.strip()
+    return out or None
+
+
+def _parse_family_gates(raw: str | None) -> dict[str, str] | None:
+    """Parse ``Contract:A,Security:B`` into {family: grade} (lowercased family keys)."""
+    if not raw:
+        return None
+    out: dict[str, str] = {}
+    for pair in raw.split(","):
+        fam, sep, grade = pair.partition(":")
+        if sep:
+            out[fam.strip().lower()] = grade.strip().upper()
+    return out or None
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/mcp_probe/cli.py
+++ b/src/mcp_probe/cli.py
@@ -52,6 +52,17 @@ def build_parser() -> argparse.ArgumentParser:
     badge.add_argument("--out", default="badge.svg", help="SVG output path")
     badge.add_argument("--endpoint-out", default=None, help="write the shields JSON endpoint too")
     badge.add_argument("--with-score", action="store_true", help="render 'A · 92' instead of 'A'")
+
+    # -- fix --
+    fix = sub.add_parser("fix", help="apply proposed legibility description rewrites (REQ-L7)")
+    fix.add_argument("target", nargs="?", help="stdio command / URL to probe, if no --from")
+    fix.add_argument("--source", required=True, help="source file whose tool descriptions to rewrite")
+    fix.add_argument("--from", dest="from_report", help="use rewrites from a saved report JSON")
+    fix.add_argument("--model", default=None, help="legibility model for a fresh probe")
+    fix.add_argument("--accept", default=None, help="comma-separated tool names to fix (default: all)")
+    fix.add_argument("--apply", action="store_true", help="write changes (default: dry-run diff)")
+    fix.add_argument("--pr", action="store_true", help="apply, commit on a branch, and open a PR via gh")
+    fix.add_argument("--allow-writes", action="store_true", help=argparse.SUPPRESS)
     return p
 
 
@@ -134,6 +145,8 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_badge(args)
     if args.command == "snapshot":
         return _cmd_snapshot(args)
+    if args.command == "fix":
+        return _cmd_fix(args)
     return _cmd_run(args)
 
 
@@ -217,6 +230,88 @@ def _cmd_badge(args: argparse.Namespace) -> int:
         Path(args.endpoint_out).write_text(
             json.dumps(shields_endpoint(grade)) + "\n", encoding="utf-8"
         )
+    return int(ExitCode.OK)
+
+
+def _cmd_fix(args: argparse.Namespace) -> int:
+    import json
+
+    from mcp_probe.fix import apply_to_file, collect_rewrites
+
+    only = set(args.accept.split(",")) if args.accept else None
+
+    # Source of rewrites: a saved report JSON, or a fresh legibility probe of the target.
+    if args.from_report:
+        report = json.loads(Path(args.from_report).read_text(encoding="utf-8"))
+    elif args.target:
+        from mcp_probe.pipeline import run_probe
+        from mcp_probe.report import report_to_dict
+
+        overrides = {
+            "target": args.target,
+            "families": ("contract", "cost", "legibility"),
+            "model": args.model,
+        }
+        config = load_config(cli_overrides={k: v for k, v in overrides.items() if v is not None})
+        try:
+            outcome = asyncio.run(run_probe(config))
+        except Exception as exc:
+            print(f"mcp-probe: probe error: {exc}", file=sys.stderr)
+            return int(ExitCode.PROBE_ERROR)
+        report = report_to_dict(outcome.report)
+    else:
+        print("mcp-probe: fix needs a target or --from report.json", file=sys.stderr)
+        return int(ExitCode.PROBE_ERROR)
+
+    rewrites = collect_rewrites(report, only=only)
+    if not rewrites:
+        print("mcp-probe: no applicable legibility rewrites found "
+              "(run with --legibility and a model, or check --accept)", file=sys.stderr)
+        return int(ExitCode.OK)
+
+    write = args.apply or args.pr
+    result = apply_to_file(args.source, rewrites, write=write)
+
+    for rw in result.applied:
+        print(f"  ✓ {rw.tool}: description rewritten")
+    for rw, reason in result.skipped:
+        print(f"  – {rw.tool}: skipped ({reason})", file=sys.stderr)
+    if result.diff and not write:
+        print("\n" + result.diff, end="")
+        print("(dry-run — pass --apply to write, or --pr to open a pull request)")
+
+    if not result.changed:
+        return int(ExitCode.OK)
+    if args.pr:
+        return _open_fix_pr(args.source, result)
+    if write:
+        print(f"\nmcp-probe: applied {len(result.applied)} rewrite(s) to {args.source}")
+    return int(ExitCode.OK)
+
+
+def _open_fix_pr(source: str, result: Any) -> int:
+    """Apply → branch → commit → PR via git + gh. Degrades to 'applied locally' on failure."""
+    import subprocess
+
+    branch = "mcp-probe/legibility-rewrites"
+    body = "Applies mcp-probe legibility description rewrites (REQ-L7):\n\n" + "\n".join(
+        f"- `{rw.tool}`" for rw in result.applied
+    )
+    steps = [
+        ["git", "checkout", "-b", branch],
+        ["git", "add", source],
+        ["git", "commit", "-m", "fix: apply mcp-probe legibility description rewrites"],
+        ["git", "push", "-u", "origin", branch],
+        ["gh", "pr", "create", "--title", "Apply mcp-probe legibility rewrites", "--body", body],
+    ]
+    try:
+        for step in steps:
+            subprocess.run(step, check=True, capture_output=True, text=True)  # noqa: S603
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        print(f"mcp-probe: changes applied locally; couldn't open PR automatically ({exc})",
+              file=sys.stderr)
+        return int(ExitCode.OK)
+    print(f"mcp-probe: opened PR from branch {branch}")
     return int(ExitCode.OK)
 
 

--- a/src/mcp_probe/cli.py
+++ b/src/mcp_probe/cli.py
@@ -63,6 +63,13 @@ def build_parser() -> argparse.ArgumentParser:
     fix.add_argument("--apply", action="store_true", help="write changes (default: dry-run diff)")
     fix.add_argument("--pr", action="store_true", help="apply, commit on a branch, and open a PR via gh")
     fix.add_argument("--allow-writes", action="store_true", help=argparse.SUPPRESS)
+
+    # -- compare --
+    cmp_ = sub.add_parser("compare", help="diff two report JSONs into a score-delta table")
+    cmp_.add_argument("baseline", help="baseline report JSON (or a history entry)")
+    cmp_.add_argument("current", help="current report JSON")
+    cmp_.add_argument("--markdown", action="store_true", help="emit the sticky PR-comment markdown")
+    cmp_.add_argument("--fail-on-regression", action="store_true", help="exit 1 if any family regressed")
     return p
 
 
@@ -76,6 +83,8 @@ def _add_common_flags(sp: argparse.ArgumentParser) -> None:
     sp.add_argument("--snapshot-path", default=None)
     sp.add_argument("--stdio-timeout", type=float, default=None)
     sp.add_argument("--transport", choices=["auto", "stdio", "streamable-http", "sse"], default=None)
+    sp.add_argument("--record", metavar="PATH", default=None, help="append this run to a history JSONL")
+    sp.add_argument("--commit", default=None, help="commit SHA for the history entry (or $GITHUB_SHA)")
 
 
 def _add_family_flags(sp: argparse.ArgumentParser) -> None:
@@ -147,6 +156,8 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_snapshot(args)
     if args.command == "fix":
         return _cmd_fix(args)
+    if args.command == "compare":
+        return _cmd_compare(args)
     return _cmd_run(args)
 
 
@@ -175,8 +186,50 @@ def _cmd_run(args: argparse.Namespace) -> int:
         Path(config.html_out).write_text(render_html(report), encoding="utf-8")
     if config.emit_stampede:
         _write_stampede_seed(report, config.emit_stampede)
+    if getattr(args, "record", None):
+        _record_history(args, report)
 
     return int(outcome.exit_code)
+
+
+def _record_history(args: argparse.Namespace, report: Any) -> None:
+    import datetime
+    import os
+
+    from mcp_probe.history import append_history, entry_from_report
+    from mcp_probe.report import report_to_dict
+
+    commit = args.commit or os.environ.get("GITHUB_SHA", "")
+    ts = datetime.datetime.now(datetime.UTC).isoformat()
+    entry = entry_from_report(report_to_dict(report, include_meta=False), commit=commit, ts=ts)
+    append_history(args.record, entry)
+
+
+def _cmd_compare(args: argparse.Namespace) -> int:
+    import json
+
+    from mcp_probe.history import compute_delta, render_delta_markdown
+
+    baseline = json.loads(Path(args.baseline).read_text(encoding="utf-8"))
+    current = json.loads(Path(args.current).read_text(encoding="utf-8"))
+    delta = compute_delta(baseline, current)
+
+    if args.markdown:
+        print(render_delta_markdown(delta), end="")
+    else:
+        oc = delta.overall_change
+        oc_str = "→0" if oc == 0 else (f"{oc:+.0f}" if oc is not None else "n/a")
+        print(f"overall: {delta.grade_before} → {delta.grade_after} ({oc_str})")
+        if delta.rubric_mismatch:
+            print("  rubric changed — per-family comparison skipped")
+        for name, (b, a) in delta.per_family.items():
+            bs = "—" if b is None else f"{b:.0f}"
+            as_ = "—" if a is None else f"{a:.0f}"
+            print(f"  {name:12} {bs:>4} → {as_:>4}")
+
+    if args.fail_on_regression and delta.has_regression:
+        return int(ExitCode.GATE_FAILURE)
+    return int(ExitCode.OK)
 
 
 def _cmd_snapshot(args: argparse.Namespace) -> int:

--- a/src/mcp_probe/cli.py
+++ b/src/mcp_probe/cli.py
@@ -102,6 +102,8 @@ def _add_family_flags(sp: argparse.ArgumentParser) -> None:
     )
     sp.add_argument("--seed", type=int, default=None)
     sp.add_argument("--concurrency", type=int, default=None)
+    sp.add_argument("--response-bloat", action="store_true",
+                    help="sample read-only tool outputs to measure response token weight (REQ-$5)")
 
 
 def _families_from_args(args: argparse.Namespace) -> tuple[str, ...]:
@@ -132,6 +134,7 @@ def _config_from_args(args: argparse.Namespace) -> ProbeConfig:
         "deep_security": _true_or_none(getattr(args, "deep_security", False)),
         "model": getattr(args, "model", None),
         "token_model": getattr(args, "token_model", None),
+        "response_bloat": _true_or_none(getattr(args, "response_bloat", False)),
         "seed": getattr(args, "seed", None),
         "concurrency": getattr(args, "concurrency", None),
         "families": _families_from_args(args) if hasattr(args, "all_families") else None,

--- a/src/mcp_probe/config.py
+++ b/src/mcp_probe/config.py
@@ -55,6 +55,9 @@ class ProbeConfig:
     # Opt-in authoritative token counting, e.g. "anthropic:claude-sonnet-5". Needs
     # ANTHROPIC_API_KEY; silently falls back to the offline tiktoken estimate otherwise.
     token_model: str | None = None
+    # Opt-in: sample read-only tool outputs to measure response token weight (REQ-$5).
+    # Live-only; adds invocation latency, so off by default. Never affects the fast-path score.
+    response_bloat: bool = False
 
     # --- performance ([net]) ---
     concurrency: int = 50

--- a/src/mcp_probe/config.py
+++ b/src/mcp_probe/config.py
@@ -33,6 +33,7 @@ class ProbeConfig:
     transport: str = "auto"  # "auto" | "stdio" | "streamable-http" | "sse"
     static_path: str | None = None  # path to a tools/list JSON dump → offline mode
     stdio_timeout: float = 60.0  # Cisco-parity default; servers may fetch deps on first run
+    headers: dict[str, str] = field(default_factory=dict)  # HTTP/SSE auth headers
 
     # --- which families to run ---
     families: tuple[str, ...] = FAST_PATH_FAMILIES  # default = zero-LLM fast path

--- a/src/mcp_probe/connect/client.py
+++ b/src/mcp_probe/connect/client.py
@@ -77,7 +77,11 @@ class FakeClient:
         if spec is None:
             return InvokeResult(tool=name, is_error=False, content={"ok": True})
         if callable(spec):
-            return spec()
+            # A callable that accepts a parameter receives the args (so a test can react to
+            # invalid input, e.g. crash on bad args); a zero-arg callable is called bare.
+            import inspect
+
+            return spec(args) if len(inspect.signature(spec).parameters) >= 1 else spec()
         return spec
 
     async def close(self) -> None:

--- a/src/mcp_probe/connect/transport.py
+++ b/src/mcp_probe/connect/transport.py
@@ -19,7 +19,7 @@ import shlex
 from contextlib import AsyncExitStack
 from typing import Any
 
-from mcp import ClientSession, StdioServerParameters, stdio_client
+from mcp import ClientSession, McpError, StdioServerParameters, stdio_client
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
 
@@ -38,7 +38,12 @@ class MCPClient:
         self.connect_record = record
 
     async def call_tool(self, name: str, args: dict[str, Any]) -> InvokeResult:
-        result = await self._session.call_tool(name, args)
+        # A JSON-RPC error (McpError) is a *clean* protocol response, not a crash — normalize
+        # it to an is_error result so engines stay SDK-agnostic and only real crashes raise.
+        try:
+            result = await self._session.call_tool(name, args)
+        except McpError as exc:
+            return InvokeResult(tool=name, is_error=True, content={"error": str(exc)}, raw=exc)
         content = [_dump(block) for block in (result.content or [])]
         return InvokeResult(
             tool=name,

--- a/src/mcp_probe/connect/transport.py
+++ b/src/mcp_probe/connect/transport.py
@@ -109,13 +109,21 @@ async def _open_streams(stack: AsyncExitStack, transport: Transport, config: Pro
         params = StdioServerParameters(command=parts[0], args=parts[1:])
         streams = await stack.enter_async_context(stdio_client(params))
         return streams[0], streams[1]
+    headers = dict(getattr(config, "headers", {}) or {})
     if transport == "streamable-http":
-        # Non-deprecated client; yields (read, write, get_session_id). Auth headers, when
-        # added, go via a passed httpx.AsyncClient (v0.2).
-        streams = await stack.enter_async_context(streamable_http_client(config.target))
+        # Non-deprecated client; yields (read, write, get_session_id). Auth headers ride on
+        # a passed httpx.AsyncClient (the new API's injection point).
+        http_client = None
+        if headers:
+            import httpx
+
+            http_client = await stack.enter_async_context(httpx.AsyncClient(headers=headers))
+        streams = await stack.enter_async_context(
+            streamable_http_client(config.target, http_client=http_client)
+        )
         return streams[0], streams[1]
     if transport == "sse":
-        streams = await stack.enter_async_context(sse_client(config.target))
+        streams = await stack.enter_async_context(sse_client(config.target, headers=headers or None))
         return streams[0], streams[1]
     raise ValueError(f"unknown transport: {transport}")
 

--- a/src/mcp_probe/contract/__init__.py
+++ b/src/mcp_probe/contract/__init__.py
@@ -3,8 +3,15 @@
 from mcp_probe.contract.schema import (
     SchemaIssue,
     synthesize_args,
+    synthesize_invalid_args,
     validate_against,
     validate_schema,
 )
 
-__all__ = ["SchemaIssue", "synthesize_args", "validate_against", "validate_schema"]
+__all__ = [
+    "SchemaIssue",
+    "synthesize_args",
+    "synthesize_invalid_args",
+    "validate_against",
+    "validate_schema",
+]

--- a/src/mcp_probe/contract/schema.py
+++ b/src/mcp_probe/contract/schema.py
@@ -137,6 +137,26 @@ def synthesize_args(schema: dict[str, Any], *, seed: int = 42, _path: str = "") 
     return _synth_string(schema, seed, _path)
 
 
+def synthesize_invalid_args(schema: dict[str, Any], *, seed: int = 42) -> dict[str, Any]:
+    """Produce a schema-*violating* argument object for error-path testing (REQ-C9).
+
+    Two violations at once, so a lenient server still gets *something* wrong: omit all
+    required fields, and type-mismatch any declared property (string↔object). A conformant
+    server should reject this cleanly; a crash/hang is the finding."""
+    if not isinstance(schema, dict) or schema.get("type") not in (None, "object"):
+        return {"__mcp_probe_unexpected__": {"nested": [1, 2, 3]}}
+    props: dict[str, Any] = schema.get("properties", {})
+    if not props:
+        # No declared shape to violate — send an unexpected nested blob.
+        return {"__mcp_probe_unexpected__": {"nested": [1, 2, 3]}}
+    bad: dict[str, Any] = {}
+    for key, sub in props.items():
+        sub_type = sub.get("type") if isinstance(sub, dict) else None
+        # flip the type: where a scalar is expected, send an object, and vice-versa
+        bad[key] = {"wrong": "type"} if sub_type in ("string", "integer", "number", "boolean") else 12345
+    return bad
+
+
 def _synth_string(schema: dict[str, Any], seed: int, path: str) -> str:
     fmt = schema.get("format")
     token = f"{_seed_int(seed, path):x}"[:6]

--- a/src/mcp_probe/engines/contract.py
+++ b/src/mcp_probe/engines/contract.py
@@ -15,7 +15,12 @@ from __future__ import annotations
 
 import re
 
-from mcp_probe.contract.schema import synthesize_args, validate_against, validate_schema
+from mcp_probe.contract.schema import (
+    synthesize_args,
+    synthesize_invalid_args,
+    validate_against,
+    validate_schema,
+)
 from mcp_probe.engines.base import EngineBase, clamp
 from mcp_probe.models import FamilyScore, Finding, ProbeContext, Severity, ToolDef
 
@@ -77,6 +82,7 @@ class ContractEngine(EngineBase):
         invoked = 0
         conformance_breaks = 0
         nondeterministic = 0
+        error_path_crashes = 0
         skipped_writes: list[str] = []
 
         if ctx.client is not None:
@@ -90,14 +96,24 @@ class ContractEngine(EngineBase):
                 broke, nondet = await self._probe_tool(ctx, tool, findings)
                 conformance_breaks += int(broke)
                 nondeterministic += int(nondet)
+                # REQ-C9: error-path — bad input must be rejected cleanly, not crash.
+                if await self._probe_error_path(ctx, tool, findings):
+                    error_path_crashes += 1
 
         # Scoring: fraction of tools passing schema + (where invoked) conformance/determinism.
         measured_live = ctx.client is not None
         total = max(1, len(tools))
-        passing = len(tools) - len(schema_invalid) - conformance_breaks - nondeterministic
+        passing = (
+            len(tools) - len(schema_invalid) - conformance_breaks - nondeterministic - error_path_crashes
+        )
         score = clamp(100.0 * passing / total)
 
-        hard_gate = bool(schema_invalid) or conformance_breaks > 0 or not self._framing_ok(ctx)
+        hard_gate = (
+            bool(schema_invalid)
+            or conformance_breaks > 0
+            or error_path_crashes > 0
+            or not self._framing_ok(ctx)
+        )
         if hard_gate:
             # A broken contract must be visible in the grade even if most tools pass.
             score = min(score, 65.0)
@@ -109,6 +125,8 @@ class ContractEngine(EngineBase):
             summary_bits.append(f"{conformance_breaks} contract break(s)")
         if nondeterministic:
             summary_bits.append(f"{nondeterministic} nondeterministic")
+        if error_path_crashes:
+            summary_bits.append(f"{error_path_crashes} crash-on-bad-input")
         if skipped_writes:
             summary_bits.append(f"{len(skipped_writes)} write tools skipped")
         summary = ", ".join(summary_bits) or f"{len(tools)} tools conform"
@@ -127,6 +145,7 @@ class ContractEngine(EngineBase):
                 "schema_invalid": sorted(schema_invalid),
                 "conformance_breaks": conformance_breaks,
                 "nondeterministic": nondeterministic,
+                "error_path_crashes": error_path_crashes,
                 "skipped_writes": skipped_writes,
                 "invocation_measured": measured_live,
                 "protocol_version": ctx.surface.protocol_version,
@@ -197,6 +216,28 @@ class ContractEngine(EngineBase):
             pass  # a second-call failure is noise; the first call already scored the tool
         return broke, nondet
 
+    async def _probe_error_path(self, ctx: ProbeContext, tool: ToolDef, findings: list[Finding]) -> bool:
+        """REQ-C9: send schema-violating args; a conformant server rejects cleanly (any
+        InvokeResult — the façade normalizes a JSON-RPC error to is_error). A raised
+        exception means a transport crash / hang. Returns True on crash."""
+        assert ctx.client is not None  # only called on the live path
+        bad = synthesize_invalid_args(tool.input_schema, seed=getattr(ctx.config, "seed", 42))
+        try:
+            await ctx.client.call_tool(tool.name, bad)
+            return False  # handled at the protocol level (clean error or tolerated) — pass
+        except Exception as exc:
+            findings.append(
+                Finding(
+                    family=self.name,
+                    code="C9-error-path",
+                    severity=Severity.HIGH,
+                    tool=tool.name,
+                    message=f"tool crashed / did not return a JSON-RPC error on malformed input: {exc!s}",
+                    remediation="validate inputs and return a spec-compliant JSON-RPC error, not a crash",
+                )
+            )
+            return True
+
     # -- handshake / framing --------------------------------------------------
 
     def _framing_ok(self, ctx: ProbeContext) -> bool:
@@ -217,15 +258,26 @@ class ContractEngine(EngineBase):
                     evidence={"errors": rec.framing_errors},
                 )
             )
-        # REQ-C2 / C10: forward-compat. Only nudge when a newer path is known-missing.
-        if rec.stateless_discover_ok is False and rec.legacy_handshake_ok:
+        # REQ-C10: forward-compat lint — flag transition risks.
+        if rec.transport == "sse":
+            findings.append(
+                Finding(
+                    family=self.name,
+                    code="C10-forward-compat",
+                    severity=Severity.LOW,
+                    message="server uses the deprecated HTTP+SSE transport",
+                    remediation="migrate to Streamable HTTP (SSE was deprecated in the 2025-03-26 spec)",
+                    evidence={"transport": "sse"},
+                )
+            )
+        elif rec.stateless_discover_ok is False and rec.legacy_handshake_ok:
             findings.append(
                 Finding(
                     family=self.name,
                     code="C10-forward-compat",
                     severity=Severity.LOW,
                     message="server speaks only the legacy initialize handshake",
-                    remediation="adopt the newer stateless discovery path when your SDK supports it",
+                    remediation="adopt the stateless server/discover path when your SDK ships it",
                     evidence={"protocol_version": rec.protocol_version},
                 )
             )

--- a/src/mcp_probe/engines/cost.py
+++ b/src/mcp_probe/engines/cost.py
@@ -31,6 +31,10 @@ from mcp_probe.tokens import (
 TOKEN_BUDGET = 2000
 # A single tool heavier than this is flagged as bloated (REQ-$2).
 PER_TOOL_BLOAT = 700
+# Above this toolset weight, lazy-loading / Tool Search starts to pay off (REQ-$6).
+REMEDIATION_THRESHOLD = 10_000
+# A single tool response heavier than this is flagged as response-bloat (REQ-$5).
+RESPONSE_BLOAT_TOKENS = 1_000
 # Penalty curve constants, anchored to the documented landmarks (see module docstring).
 _A, _B = 10.7, 1.8
 
@@ -112,6 +116,27 @@ class CostEngine(EngineBase):
                     )
                 )
 
+        # REQ-$6: remediation hint when the toolset is heavy enough that deferring pays off.
+        if toolset_tokens > REMEDIATION_THRESHOLD:
+            deferrable = toolset_tokens - TOKEN_BUDGET
+            pct = round(100 * deferrable / toolset_tokens)
+            findings.append(
+                Finding(
+                    family=self.name,
+                    code="$6-remediation",
+                    severity=Severity.INFO,
+                    message=f"toolset is {toolset_tokens} tokens; Tool Search / lazy-loading / "
+                    f"Code Mode could defer up to ~{deferrable} tokens ({pct}%) until a tool is used",
+                    remediation="adopt MCP Tool Search or load tool defs lazily; keep only "
+                    "always-needed tools eager",
+                    evidence={"toolset_tokens": toolset_tokens, "deferrable_tokens": deferrable},
+                )
+            )
+
+        # REQ-$5: response bloat (opt-in, live). Sample read-only tool outputs and measure
+        # their token weight — the *other* half of the context tax. Never affects the score.
+        response_tokens = await self._sample_responses(ctx, counter, findings)
+
         price_points = self._resolve_price_points(ctx)
         usd_by_point = {
             label: round(toolset_tokens / 1_000_000 * price, 4)
@@ -138,6 +163,7 @@ class CostEngine(EngineBase):
             "counter": counter_name,
             "counter_note": estimate_note,
             "tools": len(tools),
+            "response_tokens": response_tokens,  # dict, or "not measured"
         }
         from mcp_probe.scoring import grade_for_score
 
@@ -148,6 +174,45 @@ class CostEngine(EngineBase):
             findings=findings,
             metrics=metrics,
         )
+
+    async def _sample_responses(
+        self, ctx: ProbeContext, counter: TokenCounter, findings: list[Finding]
+    ) -> dict[str, int] | str:
+        """Invoke read-only tools and count their response tokens (REQ-$5). Opt-in + live;
+        returns "not measured" otherwise. Read-only only — never fires a destructive tool."""
+        if not getattr(ctx.config, "response_bloat", False) or ctx.client is None:
+            return "not measured"
+        import json
+
+        from mcp_probe.contract.schema import synthesize_args
+        from mcp_probe.engines.contract import _is_write
+
+        seed = getattr(ctx.config, "seed", 42)
+        out: dict[str, int] = {}
+        for t in ctx.surface.tools:
+            if _is_write(t):
+                continue
+            try:
+                result = await ctx.client.call_tool(t.name, synthesize_args(t.input_schema, seed=seed))
+                payload = result.structured if result.structured is not None else result.content
+                tokens = counter.count(json.dumps(payload, default=str, ensure_ascii=False))
+            except Exception:
+                continue
+            out[t.name] = tokens
+            if tokens > RESPONSE_BLOAT_TOKENS:
+                findings.append(
+                    Finding(
+                        family=self.name,
+                        code="$5-response-bloat",
+                        severity=Severity.LOW,
+                        tool=t.name,
+                        message=f"tool '{t.name}' returns ~{tokens} tokens per call — a large "
+                        "response tax on top of the schema tax",
+                        remediation="paginate, summarize, or let the caller select fields",
+                        evidence={"response_tokens": tokens},
+                    )
+                )
+        return out
 
     @staticmethod
     def _authoritative_total(ctx: ProbeContext, tools: tuple[ToolDef, ...]) -> int | None:

--- a/src/mcp_probe/engines/legibility.py
+++ b/src/mcp_probe/engines/legibility.py
@@ -195,8 +195,10 @@ class LegibilityEngine(EngineBase):
             tool = surface.tool(name)
             if tool is None:
                 continue
-            rewrite = model.propose_rewrite(name, tool.description or "", confusers.get(name, []))
-            rewrites.append({"tool": name, "rewrite": rewrite})
+            old = tool.description or ""
+            rewrite = model.propose_rewrite(name, old, confusers.get(name, []))
+            # Carry the exact old text so `mcp-probe fix` can find-and-replace it safely.
+            rewrites.append({"tool": name, "rewrite": rewrite, "old": old})
         return rewrites
 
     @staticmethod
@@ -221,6 +223,8 @@ class LegibilityEngine(EngineBase):
                     tool=entry["tool"],
                     message=f"'{entry['tool']}' is hard to select; a clearer description would help",
                     remediation=f"proposed: {entry['rewrite']}",
+                    # `mcp-probe fix` consumes old/rewrite to apply the change to source (REQ-L7).
+                    evidence={"old": entry.get("old", ""), "rewrite": entry["rewrite"]},
                 )
             )
         return findings

--- a/src/mcp_probe/fix.py
+++ b/src/mcp_probe/fix.py
@@ -1,0 +1,127 @@
+"""Legibility auto-fix (REQ-L7) — apply the description rewrites mcp-probe proposes.
+
+The diagnosis→fix loop: `run --legibility` emits `L5-rewrite` findings carrying the exact
+`old` description and a proposed `rewrite` (in each finding's ``evidence``). This module
+finds the old text in a target source file and replaces it with the rewrite, safely:
+
+* **Exact-match only** — the scanned description must appear verbatim in the source, or the
+  rewrite is skipped (never a fuzzy edit).
+* **Ambiguity guard** — if the old text appears more than once, skip it (can't tell which).
+* **Dry-run by default** — callers opt in to writing; opening a PR is a further opt-in.
+
+Servers that build descriptions dynamically won't match; that's reported, not forced.
+"""
+
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Rewrite:
+    tool: str
+    old: str
+    new: str
+
+
+@dataclass
+class ApplyResult:
+    applied: list[Rewrite] = field(default_factory=list)
+    skipped: list[tuple[Rewrite, str]] = field(default_factory=list)  # (rewrite, reason)
+    diff: str = ""
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.applied)
+
+
+def collect_rewrites(report: dict[str, Any], *, only: set[str] | None = None) -> list[Rewrite]:
+    """Pull (tool, old, new) rewrites out of a report's legibility L5-rewrite findings."""
+    leg = report.get("families", {}).get("legibility", {})
+    out: list[Rewrite] = []
+    for f in leg.get("findings", []):
+        if f.get("code") != "L5-rewrite":
+            continue
+        ev = f.get("evidence") or {}
+        old, new = ev.get("old"), ev.get("rewrite")
+        tool = f.get("tool")
+        if not old or not new or not tool:
+            continue  # nothing safely applicable (e.g. an empty original description)
+        if only is not None and tool not in only:
+            continue
+        out.append(Rewrite(tool=tool, old=old, new=new))
+    return out
+
+
+def _occurrences(text: str, needle: str) -> list[int]:
+    idx, out = text.find(needle), []
+    while idx != -1:
+        out.append(idx)
+        idx = text.find(needle, idx + 1)
+    return out
+
+
+def _locate(text: str, rw: Rewrite) -> tuple[int | None, str]:
+    """Return (start_index, reason). When the old text repeats, pick the occurrence
+    *nearest* the tool's name (decorator-style servers put them adjacent); a tie is
+    ambiguous and skipped. Sequential application also helps: once one identical
+    description is rewritten, the next becomes unique."""
+    occ = _occurrences(text, rw.old)
+    if not occ:
+        return None, "original description not found in source (dynamic?)"
+    if len(occ) == 1:
+        return occ[0], ""
+    tool_pos = _occurrences(text, rw.tool)
+    if not tool_pos:
+        return None, f"original appears {len(occ)}× and tool name '{rw.tool}' not in source — skipped"
+
+    def nearest(i: int) -> int:
+        return min(abs(i - tp) for tp in tool_pos)
+
+    ranked = sorted(occ, key=nearest)
+    if len(ranked) >= 2 and nearest(ranked[0]) == nearest(ranked[1]):
+        return None, f"original appears {len(occ)}× and can't be anchored to '{rw.tool}' — skipped"
+    return ranked[0], ""
+
+
+def apply_rewrites(source: str, rewrites: list[Rewrite]) -> tuple[str, ApplyResult]:
+    """Apply rewrites to ``source`` text. Returns (new_source, result). Pure — no I/O.
+
+    Replacement is index-based and re-scans after each edit, so shifting offsets are
+    handled and repeated descriptions are disambiguated by tool-name proximity."""
+    result = ApplyResult()
+    updated = source
+    for rw in rewrites:
+        if rw.old == rw.new:
+            result.skipped.append((rw, "rewrite identical to original"))
+            continue
+        start, reason = _locate(updated, rw)
+        if start is None:
+            result.skipped.append((rw, reason))
+            continue
+        updated = updated[:start] + rw.new + updated[start + len(rw.old):]
+        result.applied.append(rw)
+
+    if result.applied:
+        result.diff = "".join(
+            difflib.unified_diff(
+                source.splitlines(keepends=True),
+                updated.splitlines(keepends=True),
+                fromfile="a/source",
+                tofile="b/source",
+            )
+        )
+    return updated, result
+
+
+def apply_to_file(path: str | Path, rewrites: list[Rewrite], *, write: bool) -> ApplyResult:
+    """Apply rewrites to a file. ``write=False`` computes the diff without touching disk."""
+    p = Path(path)
+    source = p.read_text(encoding="utf-8")
+    updated, result = apply_rewrites(source, rewrites)
+    if write and result.changed:
+        p.write_text(updated, encoding="utf-8")
+    return result

--- a/src/mcp_probe/history.py
+++ b/src/mcp_probe/history.py
@@ -1,0 +1,146 @@
+"""Historical score tracking + PR score-delta rendering (issue #9).
+
+The gate says pass/fail; history says which *direction* you're trending. Each run can be
+appended to ``.mcp-probe/history.jsonl`` (one JSON object per line), and any two reports
+can be diffed into a per-family delta table — rendered for the terminal or as a sticky PR
+comment. Cross-rubric comparison is refused (scores minted under different rubrics aren't
+comparable, same rule as snapshot diffing / NFR-7).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from mcp_probe.scoring.scorer import _GRADE_ORDER
+
+# Sticky marker so a CI bot can find-and-update its own PR comment instead of spamming.
+COMMENT_MARKER = "<!-- mcp-probe-score-delta -->"
+
+
+def entry_from_report(report: dict[str, Any], *, commit: str = "", ts: str = "") -> dict[str, Any]:
+    """Project a report dict down to a compact history entry."""
+    fams = {
+        name: fam.get("score")
+        for name, fam in report.get("families", {}).items()
+        if fam.get("score") is not None
+    }
+    return {
+        "commit": commit,
+        "ts": ts,
+        "rubric_version": report.get("rubric_version", ""),
+        "overall_score": report.get("overall", {}).get("score"),
+        "overall_grade": report.get("overall", {}).get("grade"),
+        "surface_hash": report.get("target", {}).get("surface_hash", ""),
+        "families": fams,
+    }
+
+
+def append_history(path: str | Path, entry: dict[str, Any]) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def load_history(path: str | Path) -> list[dict[str, Any]]:
+    p = Path(path)
+    if not p.is_file():
+        return []
+    return [json.loads(line) for line in p.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+@dataclass
+class ScoreDelta:
+    overall_before: float | None
+    overall_after: float | None
+    grade_before: str
+    grade_after: str
+    per_family: dict[str, tuple[float | None, float | None]] = field(default_factory=dict)
+    rubric_mismatch: bool = False
+
+    @property
+    def overall_change(self) -> float | None:
+        if self.overall_before is None or self.overall_after is None:
+            return None
+        return round(self.overall_after - self.overall_before, 1)
+
+    @property
+    def grade_dropped(self) -> bool:
+        return _GRADE_ORDER.get(self.grade_after, 0) < _GRADE_ORDER.get(self.grade_before, 0)
+
+    @property
+    def has_regression(self) -> bool:
+        if self.grade_dropped:
+            return True
+        return any(
+            b is not None and a is not None and a < b - 0.05
+            for b, a in self.per_family.values()
+        )
+
+
+def compute_delta(baseline: dict[str, Any], current: dict[str, Any]) -> ScoreDelta:
+    """Diff two report dicts (or history entries): baseline → current."""
+    b_over = _overall(baseline)
+    c_over = _overall(current)
+    delta = ScoreDelta(
+        overall_before=b_over[0],
+        overall_after=c_over[0],
+        grade_before=b_over[1],
+        grade_after=c_over[1],
+        rubric_mismatch=baseline.get("rubric_version") != current.get("rubric_version"),
+    )
+    if delta.rubric_mismatch:
+        return delta  # refuse per-family comparison across rubrics
+    b_fams, c_fams = _families(baseline), _families(current)
+    for name in sorted(set(b_fams) | set(c_fams)):
+        delta.per_family[name] = (b_fams.get(name), c_fams.get(name))
+    return delta
+
+
+def _overall(doc: dict[str, Any]) -> tuple[float | None, str]:
+    if "overall" in doc:  # a report dict
+        return doc["overall"].get("score"), doc["overall"].get("grade", "?")
+    return doc.get("overall_score"), doc.get("overall_grade", "?")  # a history entry
+
+
+def _families(doc: dict[str, Any]) -> dict[str, float]:
+    if "families" in doc and doc["families"] and isinstance(next(iter(doc["families"].values())), dict):
+        return {n: f["score"] for n, f in doc["families"].items() if f.get("score") is not None}
+    return {n: s for n, s in doc.get("families", {}).items() if s is not None}  # history entry
+
+
+def _arrow(before: float | None, after: float | None) -> str:
+    if before is None or after is None:
+        return "·"
+    d = after - before
+    if abs(d) < 0.05:
+        return "→ 0"
+    return f"{'▲' if d > 0 else '▼'} {d:+.0f}"
+
+
+def render_delta_markdown(delta: ScoreDelta) -> str:
+    """The sticky PR comment body."""
+    lines = [COMMENT_MARKER, "### MCP Quality Score — change vs base", ""]
+    if delta.rubric_mismatch:
+        lines.append("⚠️ Rubric version changed vs base — scores are not comparable.")
+        return "\n".join(lines) + "\n"
+    oc = delta.overall_change
+    oc_str = "→ 0" if oc == 0 else (f"{oc:+.0f}" if oc is not None else "n/a")
+    lines += [
+        f"**Overall:** {delta.grade_before} → **{delta.grade_after}** ({oc_str})"
+        + ("  ⚠️ **regression**" if delta.has_regression else ""),
+        "",
+        "| Family | Base | PR | Δ |",
+        "|--------|------|----|---|",
+    ]
+    for name, (b, a) in delta.per_family.items():
+        lines.append(
+            f"| {name.capitalize()} | {b:.0f} | {a:.0f} | {_arrow(b, a)} |"
+            if b is not None and a is not None
+            else f"| {name.capitalize()} | {'—' if b is None else f'{b:.0f}'} "
+            f"| {'—' if a is None else f'{a:.0f}'} | · |"
+        )
+    return "\n".join(lines) + "\n"

--- a/src/mcp_probe/pipeline.py
+++ b/src/mcp_probe/pipeline.py
@@ -57,6 +57,11 @@ async def run_probe(
         if owns_client and client is not None:
             await client.close()
 
+    # REQ-S6: fold Cisco readiness findings into Performance/Contract (reliability signals,
+    # not security). Opt-in via --deep-security; best-effort; never changes the score.
+    if getattr(config, "deep_security", False):
+        _fold_readiness(config, families)
+
     scorer = Scorer()
     result = scorer.score(families)
 
@@ -158,6 +163,23 @@ def _decide_exit(config: ProbeConfig, report: Report) -> ExitCode:
         if broke or dropped:
             return ExitCode.GATE_FAILURE
     return ExitCode.OK
+
+
+def _fold_readiness(config: ProbeConfig, families: dict[str, FamilyScore]) -> None:
+    """Run readiness adapters and distribute their family-tagged findings into the matching
+    (measured) FamilyScore. Findings are attached for the report; scores are unchanged."""
+    from mcp_probe.security.adapters import DEFAULT_READINESS_ADAPTERS
+
+    target = getattr(config, "target", "") or getattr(config, "static_path", "") or ""
+    for adapter in DEFAULT_READINESS_ADAPTERS:
+        if not adapter.available():
+            continue
+        for finding in adapter.scan(target):
+            fam = families.get(finding.family)
+            if fam is not None and fam.measured:
+                fam.findings.append(finding)
+                fam.metrics.setdefault("readiness_findings", 0)
+                fam.metrics["readiness_findings"] += 1
 
 
 def gather_metrics(report: Report) -> dict[str, Any]:

--- a/src/mcp_probe/security/adapters.py
+++ b/src/mcp_probe/security/adapters.py
@@ -11,6 +11,7 @@ severity/title/tool from whatever keys appear rather than assuming a fixed schem
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 from typing import Any, Protocol
@@ -129,7 +130,7 @@ class CiscoAdapter(_ShellAdapter):
     name = "cisco-mcp-scanner"
     source: FindingSource = "cisco"
     candidates = ("mcp-scanner",)
-    args = ("--format", "raw", "--server-url")
+    args: tuple[str, ...] = ("--format", "raw", "--server-url")
 
     def _iter_issues(self, data: Any) -> list[dict[str, Any]]:
         # Flatten results[].findings[] into individual issue dicts, carrying the tool name
@@ -152,7 +153,35 @@ class CiscoAdapter(_ShellAdapter):
         return issues or super()._iter_issues(data)
 
 
+# Readiness findings that read as performance vs. everything-else → contract (REQ-S6).
+_READINESS_PERF = re.compile(r"timeout|latency|retr(y|ies)|concurren|rate.?limit|throttl|slow|load", re.I)
+
+
+class CiscoReadinessAdapter(CiscoAdapter):
+    """Cisco's ``readiness`` analyzer — production-readiness heuristics (timeouts, retries,
+    error handling). Its findings are reliability signals, so each is tagged with the
+    Performance or Contract family (not Security) for the pipeline to route (REQ-S6)."""
+
+    name = "cisco-readiness"
+    source: FindingSource = "cisco"
+    args = ("--analyzers", "readiness", "--format", "raw", "--server-url")
+
+    def _normalize(self, item: dict[str, Any]) -> Finding:
+        title = str(item.get("title", ""))
+        ident = str(item.get("id") or item.get("analyzer") or "check")
+        family = "performance" if _READINESS_PERF.search(f"{title} {ident}") else "contract"
+        return Finding(
+            family=family,
+            code=f"readiness-{ident}",
+            severity=_severity_of(item.get("severity") or "medium"),
+            tool=str(item["tool"]) if item.get("tool") else None,
+            message=f"[readiness] {title}",
+            source="cisco",
+        )
+
+
 DEFAULT_ADAPTERS: list[SecurityAdapter] = [McpScanAdapter(), CiscoAdapter()]
+DEFAULT_READINESS_ADAPTERS: list[SecurityAdapter] = [CiscoReadinessAdapter()]
 
 
 def suppress_false_positives(findings: list[Finding], *, min_confidence: float = 0.4) -> list[Finding]:

--- a/tests/test_contract_errorpath.py
+++ b/tests/test_contract_errorpath.py
@@ -1,0 +1,60 @@
+"""Contract error-path + forward-compat tests (issue #12, REQ-C9/C10)."""
+
+from __future__ import annotations
+
+from mcp_probe.config import ProbeConfig
+from mcp_probe.connect.client import ConnectRecord, FakeClient, InvokeResult
+from mcp_probe.contract.schema import synthesize_invalid_args, validate_against
+from mcp_probe.engines.contract import ContractEngine
+
+from .conftest import make_ctx
+
+_SCHEMA = {"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]}
+_TOOL = {"name": "get_x", "description": "read", "inputSchema": _SCHEMA,
+         "annotations": {"readOnlyHint": True}}
+
+
+def test_synthesize_invalid_args_violates_schema():
+    bad = synthesize_invalid_args(_SCHEMA)
+    assert validate_against(bad, _SCHEMA)  # non-empty → it genuinely violates the schema
+
+
+async def test_crash_on_bad_input_is_c9_hard_gate():
+    def handler(args):
+        # fine on valid (string) input, crashes on the malformed (dict) input
+        if not isinstance(args.get("x"), str):
+            raise RuntimeError("unhandled: cannot coerce")
+        return InvokeResult("get_x", is_error=False, content={"x": args["x"]})
+
+    client = FakeClient(results={"get_x": handler})
+    fs = await ContractEngine().run(make_ctx([_TOOL], client=client, config=ProbeConfig()))
+    assert any(f.code == "C9-error-path" for f in fs.findings)
+    assert fs.hard_gate_tripped
+    assert fs.metrics["error_path_crashes"] == 1
+
+
+async def test_clean_rejection_is_not_a_crash():
+    # Server returns a clean error result (as the façade does for McpError) → passes C9.
+    def handler(args):
+        if not isinstance(args.get("x"), str):
+            return InvokeResult("get_x", is_error=True, content={"error": "invalid params"})
+        return InvokeResult("get_x", is_error=False, content={"x": args["x"]})
+
+    client = FakeClient(results={"get_x": handler})
+    fs = await ContractEngine().run(make_ctx([_TOOL], client=client, config=ProbeConfig()))
+    assert not any(f.code == "C9-error-path" for f in fs.findings)
+    assert fs.metrics["error_path_crashes"] == 0
+
+
+async def test_c10_flags_sse_transport():
+    client = FakeClient(connect_record=ConnectRecord(transport="sse", protocol_version="2025-11-25",
+                                                     legacy_handshake_ok=True))
+    fs = await ContractEngine().run(make_ctx([_TOOL], client=client))
+    c10 = next((f for f in fs.findings if f.code == "C10-forward-compat"), None)
+    assert c10 is not None and "SSE" in c10.message
+
+
+async def test_c9_not_run_in_static_mode():
+    fs = await ContractEngine().run(make_ctx([_TOOL], client=None))  # static
+    assert fs.metrics["error_path_crashes"] == 0
+    assert not any(f.code == "C9-error-path" for f in fs.findings)

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -91,3 +91,55 @@ async def test_falls_back_to_estimate_when_authoritative_unavailable(monkeypatch
     fs = await cost_mod.CostEngine(counter=HeuristicCounter()).run(ctx)
     assert fs.metrics["counter"] == "heuristic"
     assert "estimate" in fs.metrics["counter_note"]
+
+
+async def test_remediation_hint_on_heavy_toolset():
+    # A big toolset should emit the $6 lazy-loading hint with a projected saving (REQ-$6).
+    tools = [
+        {"name": f"t{i}", "description": "word " * 200, "inputSchema": {"type": "object"}}
+        for i in range(40)
+    ]
+    from mcp_probe.engines.cost import CostEngine
+
+    fs = await CostEngine(counter=HeuristicCounter()).run(make_ctx(tools))
+    hint = next((f for f in fs.findings if f.code == "$6-remediation"), None)
+    assert hint is not None
+    assert hint.evidence["deferrable_tokens"] > 0
+    assert "Tool Search" in hint.message
+
+
+async def test_no_remediation_hint_on_lean_toolset():
+    tools = [{"name": "get_x", "description": "Return x.", "inputSchema": {"type": "object"}}]
+    from mcp_probe.engines.cost import CostEngine
+
+    fs = await CostEngine(counter=HeuristicCounter()).run(make_ctx(tools))
+    assert not any(f.code == "$6-remediation" for f in fs.findings)
+
+
+async def test_response_bloat_not_measured_by_default():
+    tools = [{"name": "get_x", "description": "Return x.", "inputSchema": {"type": "object"}}]
+    from mcp_probe.engines.cost import CostEngine
+
+    fs = await CostEngine(counter=HeuristicCounter()).run(make_ctx(tools))
+    assert fs.metrics["response_tokens"] == "not measured"
+
+
+async def test_response_bloat_sampled_when_opted_in():
+    from mcp_probe.connect.client import FakeClient, InvokeResult
+    from mcp_probe.engines.cost import CostEngine
+
+    tools = [
+        {"name": "get_small", "description": "read", "inputSchema": {"type": "object"},
+         "annotations": {"readOnlyHint": True}},
+        {"name": "get_big", "description": "read", "inputSchema": {"type": "object"},
+         "annotations": {"readOnlyHint": True}},
+    ]
+    client = FakeClient(results={
+        "get_small": InvokeResult("get_small", False, content={"ok": 1}),
+        "get_big": InvokeResult("get_big", False, content=[], structured={"rows": ["word " * 400] * 5}),
+    })
+    ctx = make_ctx(tools, client=client, config=ProbeConfig(response_bloat=True))
+    fs = await CostEngine(counter=HeuristicCounter()).run(ctx)
+    rt = fs.metrics["response_tokens"]
+    assert isinstance(rt, dict) and rt["get_big"] > rt["get_small"]
+    assert any(f.code == "$5-response-bloat" and f.tool == "get_big" for f in fs.findings)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -53,6 +53,14 @@ async def test_e2e_writes_server_skips_destructive():
     assert "delete_record" in outcome.report.families["contract"].metrics["skipped_writes"]
 
 
+async def test_e2e_error_path_clean_on_good_server():
+    # REQ-C9: a conformant server handles malformed input without crashing.
+    cfg = ProbeConfig(target=_target("good_server.py"), families=("contract",))
+    outcome = await run_probe(cfg)
+    assert outcome.report.families["contract"].metrics["error_path_crashes"] == 0
+    assert not any(f.code == "C9-error-path" for f in outcome.report.families["contract"].findings)
+
+
 async def test_e2e_7_static_mode_not_measured():
     dump = SERVERS / "dump.mcp.json"
     cfg = ProbeConfig(static_path=str(dump), families=("contract", "cost"))

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -1,0 +1,105 @@
+"""Legibility auto-fix tests (REQ-L7, issue #8) — collect + apply rewrites, incl. the
+name-anchoring that resolves identical descriptions, and an e2e through the CLI."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from mcp_probe.cli import main
+from mcp_probe.fix import Rewrite, apply_rewrites, collect_rewrites
+
+SERVERS = Path(__file__).parent / "servers"
+
+
+def _report_with_rewrites(entries: list[dict]) -> dict:
+    return {
+        "families": {
+            "legibility": {
+                "findings": [
+                    {"code": "L5-rewrite", "tool": e["tool"],
+                     "evidence": {"old": e["old"], "rewrite": e["new"]}}
+                    for e in entries
+                ]
+            }
+        }
+    }
+
+
+def test_collect_rewrites_pulls_old_and_new():
+    report = _report_with_rewrites([{"tool": "t", "old": "Old.", "new": "New, clearer."}])
+    rws = collect_rewrites(report)
+    assert rws == [Rewrite(tool="t", old="Old.", new="New, clearer.")]
+
+
+def test_collect_rewrites_respects_accept_filter():
+    report = _report_with_rewrites([
+        {"tool": "a", "old": "A", "new": "AA"},
+        {"tool": "b", "old": "B", "new": "BB"},
+    ])
+    assert [r.tool for r in collect_rewrites(report, only={"b"})] == ["b"]
+
+
+def test_apply_exact_single_match():
+    src = 'description="Old text here."\n'
+    out, res = apply_rewrites(src, [Rewrite("t", "Old text here.", "New text.")])
+    assert "New text." in out and "Old text here." not in out
+    assert res.applied and not res.skipped
+
+
+def test_apply_skips_when_not_found():
+    _out, res = apply_rewrites("nothing matches", [Rewrite("t", "absent", "x")])
+    assert not res.applied
+    assert "not found" in res.skipped[0][1]
+
+
+def test_apply_name_anchors_identical_descriptions():
+    # Both tools share the same description string — the confusable case. Anchoring by the
+    # tool name must send each rewrite to the right occurrence.
+    src = (
+        'def delete_record():\n    description="Remove a record by id."\n\n'
+        'def archive_record():\n    description="Remove a record by id."\n'
+    )
+    rws = [
+        Rewrite("delete_record", "Remove a record by id.", "Permanently delete a record by id."),
+        Rewrite("archive_record", "Remove a record by id.", "Move a record to the archive."),
+    ]
+    out, res = apply_rewrites(src, rws)
+    assert len(res.applied) == 2
+    # each rewrite landed next to its own function
+    assert "def delete_record():\n    description=\"Permanently delete a record by id.\"" in out
+    assert "def archive_record():\n    description=\"Move a record to the archive.\"" in out
+
+
+def test_cli_fix_apply_changes_confusable_server(tmp_path):
+    # e2e: apply real rewrites to a copy of the confusable fixture via the CLI.
+    src = tmp_path / "confusable_server.py"
+    shutil.copy(SERVERS / "confusable_server.py", src)
+    report = tmp_path / "report.json"
+    report.write_text(json.dumps(_report_with_rewrites([
+        {"tool": "delete_record", "old": "Remove a record by id.",
+         "new": "Permanently delete a record by id (cannot be undone)."},
+        {"tool": "archive_record", "old": "Remove a record by id.",
+         "new": "Move a record to the archive; reversible."},
+    ])), encoding="utf-8")
+
+    rc = main(["fix", "--from", str(report), "--source", str(src), "--apply"])
+    assert rc == 0
+    text = src.read_text(encoding="utf-8")
+    assert "Permanently delete a record by id" in text
+    assert "Move a record to the archive" in text
+    assert "Remove a record by id." not in text  # both originals rewritten
+
+
+def test_cli_fix_dry_run_does_not_write(tmp_path):
+    src = tmp_path / "s.py"
+    src.write_text('description="Remove a record by id."\n', encoding="utf-8")
+    report = tmp_path / "r.json"
+    report.write_text(json.dumps(_report_with_rewrites([
+        {"tool": "delete_record", "old": "Remove a record by id.", "new": "Delete it."},
+    ])), encoding="utf-8")
+    before = src.read_text(encoding="utf-8")
+    rc = main(["fix", "--from", str(report), "--source", str(src)])  # no --apply
+    assert rc == 0
+    assert src.read_text(encoding="utf-8") == before  # unchanged

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -1,0 +1,76 @@
+"""Hardening tests (issue #14): header + per-family-gate parsing, the per-family gate
+through the pipeline, and an opt-in real-scanner test."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_probe.cli import _config_from_args as cfg_from_args
+from mcp_probe.cli import _parse_family_gates, _parse_headers, build_parser
+from mcp_probe.config import ProbeConfig
+from mcp_probe.connect.discover import surface_from_tools
+from mcp_probe.exit_codes import ExitCode
+from mcp_probe.pipeline import run_probe
+
+# -- parsing ------------------------------------------------------------------
+
+def test_parse_headers():
+    assert _parse_headers(["Authorization: Bearer xyz", "X-Env: prod"]) == {
+        "Authorization": "Bearer xyz", "X-Env": "prod"
+    }
+    assert _parse_headers(None) is None
+    assert _parse_headers(["nonsense"]) is None
+
+
+def test_parse_family_gates():
+    assert _parse_family_gates("Contract:A,Security:B") == {"contract": "A", "security": "B"}
+    assert _parse_family_gates(None) is None
+
+
+def test_cli_threads_headers_and_gates_into_config():
+    args = build_parser().parse_args([
+        "run", "https://host/mcp",
+        "--header", "Authorization: Bearer t",
+        "--fail-under-family", "Contract:A",
+    ])
+    config = cfg_from_args(args)
+    assert config.headers == {"Authorization": "Bearer t"}
+    assert config.fail_under_family == {"contract": "A"}
+
+
+# -- per-family gate through the pipeline -------------------------------------
+
+BLOAT = [
+    {"name": f"t{i}", "description": "word " * 300, "inputSchema": {"type": "object"},
+     "annotations": {"readOnlyHint": True}}
+    for i in range(20)
+]
+
+
+async def test_fail_under_family_trips_on_weak_family():
+    # Cost will be well below A on this bloated surface → the per-family gate fails.
+    cfg = ProbeConfig(families=("contract", "cost"), fail_under_family={"cost": "A"})
+    outcome = await run_probe(cfg, surface=surface_from_tools(BLOAT))
+    assert outcome.report.families["cost"].grade != "A"
+    assert outcome.exit_code == ExitCode.GATE_FAILURE
+
+
+async def test_fail_under_family_passes_when_met():
+    good = [{"name": "get_x", "description": "Return x. Example: get_x().",
+             "inputSchema": {"type": "object"}, "annotations": {"readOnlyHint": True}}]
+    cfg = ProbeConfig(families=("contract", "cost"), fail_under_family={"cost": "A", "contract": "A"})
+    outcome = await run_probe(cfg, surface=surface_from_tools(good))
+    assert outcome.exit_code == ExitCode.OK
+
+
+# -- opt-in real scanner ------------------------------------------------------
+
+@pytest.mark.deep_security
+def test_real_scanner_normalizes_output():
+    from mcp_probe.security.adapters import McpScanAdapter
+
+    adapter = McpScanAdapter()
+    if not adapter.available():
+        pytest.skip("no snyk-agent-scan / mcp-scan on PATH")
+    findings = adapter.scan("tests/servers/dump.mcp.json")
+    assert isinstance(findings, list)  # normalized Finding[]; may be empty

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,91 @@
+"""History + score-delta tests (issue #9) — delta math, rubric guard, sticky markdown,
+append/load, and the CLI `compare` + `run --record` surfaces."""
+
+from __future__ import annotations
+
+import json
+
+from mcp_probe.cli import main
+from mcp_probe.history import (
+    COMMENT_MARKER,
+    append_history,
+    compute_delta,
+    entry_from_report,
+    load_history,
+    render_delta_markdown,
+)
+
+
+def _report(overall, grade, fams, rubric="2026.07.1"):
+    return {
+        "rubric_version": rubric,
+        "overall": {"score": overall, "grade": grade},
+        "target": {"surface_hash": "sha256:abc"},
+        "families": {n: {"score": s, "grade": "?"} for n, s in fams.items()},
+    }
+
+
+def test_compute_delta_math():
+    base = _report(80, "B", {"cost": 90, "contract": 70})
+    cur = _report(75, "C", {"cost": 85, "contract": 65})
+    d = compute_delta(base, cur)
+    assert d.overall_change == -5.0
+    assert d.grade_dropped is True
+    assert d.per_family["cost"] == (90, 85)
+    assert d.has_regression is True
+
+
+def test_no_regression_when_flat_or_up():
+    base = _report(80, "B", {"cost": 80})
+    cur = _report(82, "B", {"cost": 82})
+    d = compute_delta(base, cur)
+    assert d.has_regression is False
+
+
+def test_rubric_mismatch_refuses_family_diff():
+    base = _report(80, "B", {"cost": 80}, rubric="1999.01.0")
+    cur = _report(20, "F", {"cost": 20}, rubric="2026.07.1")
+    d = compute_delta(base, cur)
+    assert d.rubric_mismatch is True
+    assert d.per_family == {}
+
+
+def test_markdown_has_marker_and_table():
+    base = _report(80, "B", {"cost": 90})
+    cur = _report(70, "C", {"cost": 70})
+    md = render_delta_markdown(compute_delta(base, cur))
+    assert md.startswith(COMMENT_MARKER)
+    assert "regression" in md
+    assert "| Family | Base | PR | Δ |" in md
+
+
+def test_history_roundtrip(tmp_path):
+    path = tmp_path / "history.jsonl"
+    entry = entry_from_report(_report(90, "A", {"cost": 90}), commit="abc123", ts="2026-01-01T00:00:00Z")
+    append_history(path, entry)
+    append_history(path, entry_from_report(_report(85, "B", {"cost": 85}), commit="def456"))
+    hist = load_history(path)
+    assert len(hist) == 2
+    assert hist[0]["commit"] == "abc123"
+    assert hist[0]["overall_grade"] == "A"
+
+
+def test_cli_compare_markdown(tmp_path, capsys):
+    base = tmp_path / "base.json"
+    cur = tmp_path / "cur.json"
+    base.write_text(json.dumps(_report(80, "B", {"cost": 90})), encoding="utf-8")
+    cur.write_text(json.dumps(_report(70, "C", {"cost": 70})), encoding="utf-8")
+    rc = main(["compare", str(base), str(cur), "--markdown"])
+    assert rc == 0
+    assert COMMENT_MARKER in capsys.readouterr().out
+
+
+def test_cli_compare_fail_on_regression(tmp_path):
+    base = tmp_path / "base.json"
+    cur = tmp_path / "cur.json"
+    base.write_text(json.dumps(_report(80, "B", {"cost": 90})), encoding="utf-8")
+    cur.write_text(json.dumps(_report(60, "D", {"cost": 60})), encoding="utf-8")
+    assert main(["compare", str(base), str(cur), "--fail-on-regression"]) == 1
+    # and passes (exit 0) when improved
+    cur.write_text(json.dumps(_report(95, "A", {"cost": 95})), encoding="utf-8")
+    assert main(["compare", str(base), str(cur), "--fail-on-regression"]) == 0

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,0 +1,90 @@
+"""Cisco readiness adapter tests (issue #13, REQ-S6) — parse + family routing, and the
+pipeline fold into Performance/Contract."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mcp_probe.config import ProbeConfig
+from mcp_probe.models import FamilyScore, Finding, Severity
+from mcp_probe.security.adapters import CiscoReadinessAdapter
+
+
+def _readiness_json() -> str:
+    return json.dumps({
+        "results": [{
+            "name": "fetch_data", "type": "tool", "severity": "MEDIUM",
+            "findings": [
+                {"analyzer": "readiness", "severity": "MEDIUM", "threat_summary": "no request timeout configured",
+                 "details": [{"name": "timeout-missing", "description": "no timeout"}]},
+                {"analyzer": "readiness", "severity": "LOW", "threat_summary": "errors are not handled",
+                 "details": [{"name": "error-handling", "description": "unhandled errors"}]},
+            ],
+        }],
+    })
+
+
+def test_readiness_routes_to_perf_and_contract():
+    findings = CiscoReadinessAdapter()._parse(_readiness_json())
+    by_family = {f.family: f for f in findings}
+    assert by_family["performance"].code.startswith("readiness-timeout")
+    assert by_family["contract"].code.startswith("readiness-error")
+    assert all(f.source == "cisco" for f in findings)
+
+
+class _FakeReadiness:
+    name = "fake-readiness"
+
+    def available(self) -> bool:
+        return True
+
+    def scan(self, target: str):
+        return [
+            Finding("performance", "readiness-timeout", Severity.MEDIUM, "[readiness] no timeout", source="cisco"),
+            Finding("contract", "readiness-error-handling", Severity.LOW, "[readiness] unhandled", source="cisco"),
+        ]
+
+
+async def test_pipeline_folds_readiness_into_families(monkeypatch):
+    from mcp_probe import pipeline
+
+    monkeypatch.setattr(
+        "mcp_probe.security.adapters.DEFAULT_READINESS_ADAPTERS", [_FakeReadiness()], raising=True
+    )
+    families = {
+        "contract": FamilyScore("contract", 100, "A"),
+        "performance": FamilyScore("performance", 90, "A"),
+    }
+    pipeline._fold_readiness(ProbeConfig(deep_security=True, target="x"), families)
+    assert any(f.code == "readiness-timeout" for f in families["performance"].findings)
+    assert any(f.code == "readiness-error-handling" for f in families["contract"].findings)
+    assert families["performance"].metrics["readiness_findings"] == 1
+
+
+async def test_pipeline_skips_when_family_not_measured(monkeypatch):
+    from mcp_probe import pipeline
+
+    monkeypatch.setattr(
+        "mcp_probe.security.adapters.DEFAULT_READINESS_ADAPTERS", [_FakeReadiness()], raising=True
+    )
+    # performance not measured (static) → its readiness finding is dropped, not attached
+    families = {
+        "contract": FamilyScore("contract", 100, "A"),
+        "performance": FamilyScore.not_measured("performance", "static"),
+    }
+    pipeline._fold_readiness(ProbeConfig(deep_security=True, target="x"), families)
+    assert families["performance"].findings == []
+    assert any(f.code == "readiness-error-handling" for f in families["contract"].findings)
+
+
+@pytest.mark.parametrize("text,family", [
+    ("request timeout too low", "performance"),
+    ("retries not configured", "performance"),
+    ("no input validation", "contract"),
+    ("missing error handling", "contract"),
+])
+def test_readiness_routing_heuristic(text, family):
+    item = {"tool": "t", "severity": "low", "title": text, "id": text.split()[0]}
+    assert CiscoReadinessAdapter()._normalize(item).family == family


### PR DESCRIPTION
Closes #14. Three gaps from the v0.1 build, so the tool covers the real world.

## What
- **HTTP/SSE auth headers**: `--header 'Authorization: Bearer …'` (repeatable) → threaded through an `httpx.AsyncClient` (Streamable-HTTP) or `headers=` (SSE). **Unblocks probing credential-gated servers.**
- **`--fail-under-family Contract:A,Security:B`**: wires the per-family gate the scorer/config already supported.
- **Opt-in real-scanner test** (`-m deep_security`): runs an installed `snyk-agent-scan`/`mcp-scanner` and asserts normalized output; skips cleanly when absent (the `--deep-security` analogue of `live_llm`).
- Leaderboard script gains `--header` + auto HTTP detection, so it can score authed HTTP servers.

## e2e verified
- Component tests: header + gate parsing, CLI→config threading, per-family gate trips/passes through the pipeline.
- **Live**: per-family gate (`good` passes `Cost:A,Contract:A`; `bloated` fails `Cost:A`); a real Streamable-HTTP probe **with an `Authorization` header** connected and graded A. Full suite **133 passing**, ruff + mypy clean.

## Stack
#14, on top of #13. Merge order: #8 → #9 → #11 → #12 → #13 → #14.