### PR TITLE
feat(contract): error-recovery affordance (closes #25)

### DIFF
--- a/src/mcp_quality/contract/__init__.py
+++ b/src/mcp_quality/contract/__init__.py
@@ -1,5 +1,6 @@
-"""Contract family internals: JSON-Schema validation + deterministic arg synthesis."""
+"""Contract family internals: JSON-Schema validation, arg synthesis, error grading."""
 
+from mcp_quality.contract.errors import ErrorAffordance, grade_error_payload
 from mcp_quality.contract.schema import (
     SchemaIssue,
     synthesize_args,
@@ -10,6 +11,8 @@ from mcp_quality.contract.schema import (
 
 __all__ = [
     "SchemaIssue",
+    "ErrorAffordance",
+    "grade_error_payload",
     "synthesize_args",
     "synthesize_invalid_args",
     "validate_against",

--- a/src/mcp_quality/contract/errors.py
+++ b/src/mcp_quality/contract/errors.py
@@ -1,0 +1,120 @@
+"""Error-recovery affordance grading (issue #25).
+
+When a tool fails, the *shape* of the error it returns decides whether the agent recovers
+or spirals: a structured, actionable error lets the agent fix-and-retry; a vague "something
+went wrong" makes it invent a recovery and run it against a live system. This module grades
+the error payload an agent would actually receive — pure, so it's fully unit-testable.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from mcp_quality.models import Finding, Severity
+
+# Leaked internals — a stack trace / path / exception class / secret in an error payload.
+_LEAK_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("stack-trace", re.compile(r"Traceback \(most recent call last\)|File \"[^\"]+\", line \d+")),
+    ("exception-class", re.compile(r"\b[A-Za-z_]+(Error|Exception)\b:")),
+    ("filesystem-path", re.compile(r"(/(usr|home|Users|var|opt|etc)/|[A-Za-z]:\\\\)")),
+    ("secret", re.compile(r"\bsk-[A-Za-z0-9]{16,}\b|\bAKIA[0-9A-Z]{16}\b|BEGIN (RSA )?PRIVATE KEY")),
+]
+
+# A bare/generic message with nothing an agent can act on.
+_OPAQUE = re.compile(
+    r"^(error|failed|failure|something went wrong|internal( server)? error|unknown error"
+    r"|bad request|invalid|not ?ok|\d{3})\.?$",
+    re.I,
+)
+
+# Signals that the error tells the agent how to recover.
+_ACTIONABLE = re.compile(
+    r"\b(retry|retryable|retry[_-]?after|must be|required|expected|provide|missing|"
+    r"invalid value|out of range|did you mean|use \w+ instead|not found|unauthorized|"
+    r"rate ?limit|too large|exceeds)\b",
+    re.I,
+)
+
+
+@dataclass
+class ErrorAffordance:
+    affordance: int  # 0..100 — how recoverable the error is for an agent
+    findings: list[Finding]
+
+
+def error_text(result: Any) -> str:
+    """Flatten an InvokeResult's payload (content blocks / structured) into one string."""
+    parts: list[str] = []
+    structured = getattr(result, "structured", None)
+    if structured is not None:
+        parts.append(json.dumps(structured, default=str, ensure_ascii=False))
+    content = getattr(result, "content", None)
+    if isinstance(content, str):
+        parts.append(content)
+    elif isinstance(content, dict):
+        parts.append(json.dumps(content, default=str, ensure_ascii=False))
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict):
+                parts.append(str(block.get("text") or json.dumps(block, default=str, ensure_ascii=False)))
+            else:
+                parts.append(str(block))
+    return " ".join(p for p in parts if p).strip()
+
+
+def grade_error_payload(tool: str, result: Any) -> ErrorAffordance:
+    """Grade the error a tool returned for malformed input (issue #25).
+
+    Cases: (1) leaked internals → HIGH, big penalty; (2) opaque/generic → MEDIUM;
+    (3) some text but no actionable guidance → LOW; (4) actionable → clean, high score.
+    A tool that returns a *non-error* for schema-invalid input gets a LOW 'silent-accept'.
+    """
+    findings: list[Finding] = []
+    is_error = bool(getattr(result, "is_error", False))
+    text = error_text(result)
+
+    if not is_error:
+        findings.append(
+            _f("C11-silent-accept", Severity.LOW, tool,
+               "tool returned a non-error result for schema-invalid input — no signal to correct",
+               "reject invalid input with a clear error result")
+        )
+        return ErrorAffordance(affordance=45, findings=findings)
+
+    leaked = [label for label, pat in _LEAK_PATTERNS if pat.search(text)]
+    if leaked:
+        findings.append(
+            _f("C11-error-leak", Severity.HIGH, tool,
+               f"error payload leaks internals ({', '.join(leaked)}) — info disclosure + hurts recovery",
+               "return a clean, categorized error; never surface stack traces / paths / secrets",
+               evidence={"leaked": leaked})
+        )
+        return ErrorAffordance(affordance=25, findings=findings)
+
+    stripped = text.strip()
+    if not stripped or _OPAQUE.match(stripped):
+        findings.append(
+            _f("C11-error-opaque", Severity.MEDIUM, tool,
+               "error payload is opaque ('something went wrong') — the agent can't tell what to fix",
+               "include a category/code and what the caller should change")
+        )
+        return ErrorAffordance(affordance=40, findings=findings)
+
+    if not _ACTIONABLE.search(text):
+        findings.append(
+            _f("C11-error-unactionable", Severity.LOW, tool,
+               "error has detail but no actionable guidance (what to change, retryable, alternative)",
+               "state the fix: which field, whether it's retryable, or an alternative tool")
+        )
+        return ErrorAffordance(affordance=70, findings=findings)
+
+    return ErrorAffordance(affordance=100, findings=findings)
+
+
+def _f(code: str, sev: Severity, tool: str, message: str, remediation: str,
+       evidence: dict | None = None) -> Finding:
+    return Finding(family="contract", code=code, severity=sev, tool=tool,
+                   message=message, remediation=remediation, evidence=evidence)

--- a/src/mcp_quality/engines/contract.py
+++ b/src/mcp_quality/engines/contract.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import re
 
+from mcp_quality.contract.errors import grade_error_payload
 from mcp_quality.contract.schema import (
     synthesize_args,
     synthesize_invalid_args,
@@ -83,6 +84,7 @@ class ContractEngine(EngineBase):
         conformance_breaks = 0
         nondeterministic = 0
         error_path_crashes = 0
+        recovery_scores: list[int] = []  # per-tool error-recovery affordance (issue #25)
         skipped_writes: list[str] = []
 
         if ctx.client is not None:
@@ -96,9 +98,11 @@ class ContractEngine(EngineBase):
                 broke, nondet = await self._probe_tool(ctx, tool, findings)
                 conformance_breaks += int(broke)
                 nondeterministic += int(nondet)
-                # REQ-C9: error-path — bad input must be rejected cleanly, not crash.
-                if await self._probe_error_path(ctx, tool, findings):
-                    error_path_crashes += 1
+                # REQ-C9 + #25: bad input must not crash, and the error must be recoverable.
+                crashed, affordance = await self._probe_error_path(ctx, tool, findings)
+                error_path_crashes += int(crashed)
+                if affordance is not None:
+                    recovery_scores.append(affordance)
 
         # Scoring: fraction of tools passing schema + (where invoked) conformance/determinism.
         measured_live = ctx.client is not None
@@ -107,6 +111,12 @@ class ContractEngine(EngineBase):
             len(tools) - len(schema_invalid) - conformance_breaks - nondeterministic - error_path_crashes
         )
         score = clamp(100.0 * passing / total)
+
+        # #25: nudge the grade for poor error-recovery affordance (bounded, non-gating —
+        # vague errors are a quality problem, not a conformance break).
+        mean_affordance = round(sum(recovery_scores) / len(recovery_scores)) if recovery_scores else None
+        if mean_affordance is not None:
+            score = clamp(score - min(15.0, (100 - mean_affordance) * 0.15))
 
         hard_gate = (
             bool(schema_invalid)
@@ -127,6 +137,8 @@ class ContractEngine(EngineBase):
             summary_bits.append(f"{nondeterministic} nondeterministic")
         if error_path_crashes:
             summary_bits.append(f"{error_path_crashes} crash-on-bad-input")
+        if mean_affordance is not None and mean_affordance < 70:
+            summary_bits.append(f"error-recovery {mean_affordance}/100")
         if skipped_writes:
             summary_bits.append(f"{len(skipped_writes)} write tools skipped")
         summary = ", ".join(summary_bits) or f"{len(tools)} tools conform"
@@ -146,6 +158,7 @@ class ContractEngine(EngineBase):
                 "conformance_breaks": conformance_breaks,
                 "nondeterministic": nondeterministic,
                 "error_path_crashes": error_path_crashes,
+                "error_recovery_affordance": mean_affordance,
                 "skipped_writes": skipped_writes,
                 "invocation_measured": measured_live,
                 "protocol_version": ctx.surface.protocol_version,
@@ -216,15 +229,18 @@ class ContractEngine(EngineBase):
             pass  # a second-call failure is noise; the first call already scored the tool
         return broke, nondet
 
-    async def _probe_error_path(self, ctx: ProbeContext, tool: ToolDef, findings: list[Finding]) -> bool:
-        """REQ-C9: send schema-violating args; a conformant server rejects cleanly (any
-        InvokeResult — the façade normalizes a JSON-RPC error to is_error). A raised
-        exception means a transport crash / hang. Returns True on crash."""
+    async def _probe_error_path(
+        self, ctx: ProbeContext, tool: ToolDef, findings: list[Finding]
+    ) -> tuple[bool, int | None]:
+        """REQ-C9 + #25: send schema-violating args, then judge the response.
+
+        Returns ``(crashed, affordance)``. A raised exception = transport crash/hang
+        (crashed=True, affordance=None, C9 finding). Otherwise the error payload is graded
+        for how recoverable it is for an agent (#25) — 0..100 with C11 findings."""
         assert ctx.client is not None  # only called on the live path
         bad = synthesize_invalid_args(tool.input_schema, seed=getattr(ctx.config, "seed", 42))
         try:
-            await ctx.client.call_tool(tool.name, bad)
-            return False  # handled at the protocol level (clean error or tolerated) — pass
+            result = await ctx.client.call_tool(tool.name, bad)
         except Exception as exc:
             findings.append(
                 Finding(
@@ -236,7 +252,10 @@ class ContractEngine(EngineBase):
                     remediation="validate inputs and return a spec-compliant JSON-RPC error, not a crash",
                 )
             )
-            return True
+            return True, None
+        graded = grade_error_payload(tool.name, result)
+        findings.extend(graded.findings)
+        return False, graded.affordance
 
     # -- handshake / framing --------------------------------------------------
 

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -70,7 +70,7 @@ async def test_deterministic_tool_passes():
     ctx = make_ctx(tools, client=client)
     fs = await ContractEngine().run(ctx)
     assert not any(f.code == "C5-nondeterminism" for f in fs.findings)
-    assert fs.score == 100
+    assert fs.grade == "A"  # deterministic + conformant → A (exact score also reflects #25 error-recovery)
 
 
 # -- output conformance (REQ-C4) ----------------------------------------------

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -57,8 +57,12 @@ async def test_e2e_error_path_clean_on_good_server():
     # REQ-C9: a conformant server handles malformed input without crashing.
     cfg = ProbeConfig(target=_target("good_server.py"), families=("contract",))
     outcome = await run_probe(cfg)
-    assert outcome.report.families["contract"].metrics["error_path_crashes"] == 0
-    assert not any(f.code == "C9-error-path" for f in outcome.report.families["contract"].findings)
+    contract = outcome.report.families["contract"]
+    assert contract.metrics["error_path_crashes"] == 0
+    assert not any(f.code == "C9-error-path" for f in contract.findings)
+    # #25: error-recovery affordance is measured live and in range.
+    aff = contract.metrics["error_recovery_affordance"]
+    assert aff is not None and 0 <= aff <= 100
 
 
 async def test_e2e_7_static_mode_not_measured():

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -1,0 +1,85 @@
+"""Error-recovery affordance tests (issue #25) — grade the failure-path payload."""
+
+from __future__ import annotations
+
+from mcp_quality.config import ProbeConfig
+from mcp_quality.connect.client import FakeClient, InvokeResult
+from mcp_quality.contract.errors import grade_error_payload
+from mcp_quality.engines.contract import ContractEngine
+
+from .conftest import make_ctx
+
+_TOOL = {"name": "lookup", "description": "look up a record",
+         "inputSchema": {"type": "object", "properties": {"id": {"type": "string"}}, "required": ["id"]},
+         "annotations": {"readOnlyHint": True}}
+
+
+def _err(text=None, structured=None):
+    return InvokeResult("lookup", is_error=True, content=(text if text is not None else []),
+                        structured=structured)
+
+
+# -- the pure grader ----------------------------------------------------------
+
+def test_actionable_error_scores_full():
+    g = grade_error_payload("lookup", _err("Invalid value for 'id': expected a UUID string. Retryable: no."))
+    assert g.affordance == 100 and g.findings == []
+
+
+def test_opaque_error_flagged():
+    g = grade_error_payload("lookup", _err("Something went wrong"))
+    assert g.affordance <= 40
+    assert any(f.code == "C11-error-opaque" for f in g.findings)
+
+
+def test_leaked_stacktrace_is_high_severity():
+    tb = 'Traceback (most recent call last):\n  File "/usr/lib/app/handler.py", line 42, in run\n    raise ValueError: bad id'
+    g = grade_error_payload("lookup", _err(tb))
+    leak = next((f for f in g.findings if f.code == "C11-error-leak"), None)
+    assert leak is not None and leak.severity.name == "HIGH"
+    assert g.affordance <= 30
+
+
+def test_detail_but_no_guidance_is_low():
+    g = grade_error_payload("lookup", _err("The identifier you passed does not correspond to anything in our system"))
+    assert any(f.code == "C11-error-unactionable" for f in g.findings)
+    assert 50 <= g.affordance < 100
+
+
+def test_silent_accept_of_invalid_input():
+    ok = InvokeResult("lookup", is_error=False, content={"result": "ok"})
+    g = grade_error_payload("lookup", ok)
+    assert any(f.code == "C11-silent-accept" for f in g.findings)
+
+
+def test_structured_error_payload_read():
+    g = grade_error_payload("lookup", _err(structured={"code": "NOT_FOUND", "message": "id not found; provide a valid id"}))
+    assert g.affordance == 100  # 'not found' + 'provide' are actionable signals
+
+
+# -- wired into the Contract engine -------------------------------------------
+
+async def test_engine_surfaces_affordance_and_penalizes():
+    # server returns an opaque error on bad input → C11 finding + affordance recorded
+    client = FakeClient(results={"lookup": lambda args: (
+        InvokeResult("lookup", is_error=False, content={"row": 1}) if isinstance(args.get("id"), str)
+        else InvokeResult("lookup", is_error=True, content="error"))})
+    fs = await ContractEngine().run(make_ctx([_TOOL], client=client, config=ProbeConfig()))
+    assert fs.metrics["error_recovery_affordance"] is not None
+    assert any(f.code.startswith("C11-error") for f in fs.findings)
+
+
+async def test_engine_good_errors_no_penalty(monkeypatch):
+    client = FakeClient(results={"lookup": lambda args: (
+        InvokeResult("lookup", is_error=False, content={"row": 1}) if isinstance(args.get("id"), str)
+        else InvokeResult("lookup", is_error=True,
+                          content="Invalid value for 'id': expected a non-empty string; not retryable."))})
+    fs = await ContractEngine().run(make_ctx([_TOOL], client=client, config=ProbeConfig()))
+    assert fs.metrics["error_recovery_affordance"] == 100
+    assert not any(f.code.startswith("C11-error") for f in fs.findings)
+    assert fs.score == 100  # perfect affordance → no recovery penalty
+
+
+async def test_error_recovery_not_measured_in_static():
+    fs = await ContractEngine().run(make_ctx([_TOOL], client=None))
+    assert fs.metrics["error_recovery_affordance"] is None


### PR DESCRIPTION
Closes #25. Extends the C9 error-path probe from "did the server crash on bad input?" to "**is the error it returned usable by an agent?**" — the payload shape decides whether an agent fixes-and-retries or invents a recovery and runs it against a live system.

## What
- New `contract/errors.py::grade_error_payload` (pure, unit-tested): sends the malformed-arg call, then grades the returned error 0–100 —
  - **leaked internals** (stack trace / path / exception class / secret) → `C11-error-leak`, HIGH
  - **opaque** ("something went wrong") → `C11-error-opaque`, MEDIUM
  - **detail but no guidance** → `C11-error-unactionable`, LOW
  - **silent-accept** of invalid input (non-error result) → `C11-silent-accept`, LOW
  - actionable (fix / retryable / alternative) → clean, 100
- Wired into the Contract probe; per-tool affordance averaged into `metrics.error_recovery_affordance`, with a **bounded (≤15pt) non-gating penalty** — vague errors are a quality issue, not a conformance break.

## e2e verified
- 9 unit tests (each error class + engine wiring + static not-measured) + a live e2e.
- **Live:** on `good_server`, affordance **58/100** — even FastMCP's default validation errors carry detail but no explicit fix/retry guidance (a real, honest finding). Full suite **148 + 9 e2e** green, ruff + mypy clean.

First of the v0.3 behavioral-conformance wave; branches off `main`.