### PR TITLE
feat(legibility): tool-description quality lints (closes #30)

### DIFF
--- a/src/mcp_quality/legibility/lints.py
+++ b/src/mcp_quality/legibility/lints.py
@@ -16,6 +16,21 @@ _VAGUE = re.compile(r"\b(various|stuff|things|data|misc|etc\.?|and more|handles?
 _HAS_EXAMPLE = re.compile(r"(example|e\.g\.|for instance|usage:)", re.I)
 OVER_LONG_CHARS = 600  # descriptions longer than this waste context on every turn
 
+# Generic param names an agent can't reason about (kept tight to avoid false positives;
+# common-and-fine names like id/name/query/url/path/key/value are intentionally excluded).
+_AMBIGUOUS_PARAMS = {
+    "data", "obj", "arg", "args", "input", "param", "params", "tmp", "temp",
+    "foo", "bar", "thing", "things", "stuff", "payload", "info",
+}
+# Tools whose name implies they return a collection — they should support pagination.
+_COLLECTION_TOOL = re.compile(r"(^|_)(list|search|query|find|browse|feed|history|recent|all)(_|$)", re.I)
+_PAGINATION_PARAMS = {
+    "limit", "offset", "cursor", "page", "per_page", "page_size", "pagesize",
+    "page_token", "max_results", "maxresults", "count", "top", "after", "before",
+}
+# Low-level identifiers that shouldn't leak into agent-facing descriptions.
+_LEAKED_ID = re.compile(r"\b(uuid|guid|mime_?type|base64|[0-9]{2,4}px|etag|checksum|sha-?256)\b", re.I)
+
 
 def lint_descriptions(surface: ServerSurface) -> list[Finding]:
     findings: list[Finding] = []
@@ -45,6 +60,22 @@ def lint_descriptions(surface: ServerSurface) -> list[Finding]:
             findings.append(_f("L3-undocumented-params", Severity.LOW, t.name,
                                "no parameter has a description",
                                "describe each parameter so agents fill them correctly"))
+        # ambiguous param names — a model can't reason about `data`/`obj`/single letters
+        ambiguous = sorted(p for p in props if p.lower() in _AMBIGUOUS_PARAMS or len(p) == 1)
+        if ambiguous:
+            findings.append(_f("L3-ambiguous-param", Severity.LOW, t.name,
+                               f"generic parameter name(s): {', '.join(ambiguous)}",
+                               "use specific names (e.g. `user_id`, not `id`/`data`)"))
+        # collection tools should paginate — unbounded lists blow the context window
+        if _COLLECTION_TOOL.search(t.name) and not (set(map(str.lower, props)) & _PAGINATION_PARAMS):
+            findings.append(_f("L3-no-pagination", Severity.LOW, t.name,
+                               "looks like it returns a collection but has no pagination param",
+                               "add a `limit`/`cursor` so callers can bound the response"))
+        # low-level identifiers leaking into the agent-facing description
+        if _LEAKED_ID.search(desc):
+            findings.append(_f("L3-leaked-identifier", Severity.INFO, t.name,
+                               "description exposes a low-level identifier (uuid/mime_type/etc.)",
+                               "describe behaviour in the caller's terms, not implementation details"))
     return findings
 
 

--- a/tests/test_description_lints.py
+++ b/tests/test_description_lints.py
@@ -1,0 +1,67 @@
+"""Description-quality lint tests (issue #30) — the new offline L3 sub-lints."""
+
+from __future__ import annotations
+
+from mcp_quality.legibility.lints import lint_descriptions
+
+from .conftest import make_surface
+
+
+def _codes(tools):
+    return {f.code for f in lint_descriptions(make_surface(tools))}
+
+
+def test_ambiguous_param_flagged():
+    codes = _codes([{"name": "run", "description": "Run a job. Example: run(data=...).",
+                     "inputSchema": {"type": "object", "properties": {"data": {"type": "object"}}}}])
+    assert "L3-ambiguous-param" in codes
+
+
+def test_single_char_param_flagged():
+    codes = _codes([{"name": "plot", "description": "Plot. Example: plot(x=1).",
+                     "inputSchema": {"type": "object", "properties": {"x": {"type": "number"}}}}])
+    assert "L3-ambiguous-param" in codes
+
+
+def test_specific_param_not_flagged():
+    codes = _codes([{"name": "get_user", "description": "Get a user. Example: get_user(user_id='u1').",
+                     "inputSchema": {"type": "object",
+                                     "properties": {"user_id": {"type": "string", "description": "the id"}}}}])
+    assert "L3-ambiguous-param" not in codes
+
+
+def test_collection_tool_without_pagination_flagged():
+    codes = _codes([{"name": "list_records", "description": "List records. Example: list_records().",
+                     "inputSchema": {"type": "object", "properties": {}}}])
+    assert "L3-no-pagination" in codes
+
+
+def test_collection_tool_with_pagination_ok():
+    codes = _codes([{"name": "search_docs", "description": "Search docs. Example: search_docs(q='x').",
+                     "inputSchema": {"type": "object",
+                                     "properties": {"q": {"type": "string", "description": "query"},
+                                                    "limit": {"type": "integer", "description": "max"}}}}])
+    assert "L3-no-pagination" not in codes
+
+
+def test_non_collection_tool_not_flagged_for_pagination():
+    codes = _codes([{"name": "get_weather", "description": "Weather. Example: get_weather(city='x').",
+                     "inputSchema": {"type": "object",
+                                     "properties": {"city": {"type": "string", "description": "city"}}}}])
+    assert "L3-no-pagination" not in codes
+
+
+def test_leaked_identifier_flagged():
+    codes = _codes([{"name": "get_img", "description": "Return the 256px_url and mime_type of an image.",
+                     "inputSchema": {"type": "object", "properties": {}}}])
+    assert "L3-leaked-identifier" in codes
+
+
+def test_clean_tool_has_no_new_lints():
+    codes = _codes([{"name": "get_weather",
+                     "description": "Return the current weather for a city. Example: get_weather(city='Paris').",
+                     "inputSchema": {"type": "object",
+                                     "properties": {"city": {"type": "string", "description": "City name"}},
+                                     "required": ["city"]}}])
+    for c in ("L3-ambiguous-param", "L3-no-pagination", "L3-leaked-identifier"):
+        assert c not in codes


### PR DESCRIPTION
Closes #30. Three new **offline, deterministic** description lints (no model, runs in ms):

- **`L3-ambiguous-param`** — generic param names (`data`, `obj`, single letters) an agent can't reason about. Blocklist kept tight; common-and-fine names (`id`, `name`, `query`, `url`, `value`) are intentionally excluded.
- **`L3-no-pagination`** — a tool whose name implies a collection (`list_`/`search_`/`find_`/…) but has no `limit`/`cursor`/`offset` param → unbounded responses that blow the context window.
- **`L3-leaked-identifier`** — low-level identifiers (`uuid`, `mime_type`, `256px`, `etag`…) leaking into the agent-facing description.

**Deferred (on purpose): namespacing.** Doing it with low false positives needs domain awareness (distinguishing `github_*` grouping from incidental shared verbs); a noisy lint would undermine the suite's "signal, not noise" value. Tracked for later rather than shipped half-baked.

## Verified
- 8 unit tests (each lint, positive + negative).
- **Low-FP check on a real 15-tool production surface:** all three stayed silent (well-named params, real pagination, clean descriptions) while the existing lints still flagged the genuine gap. Full suite **156** green, ruff + mypy clean.

v0.3, branches off `main` (independent of #25).