### PR TITLE
feat(cost): Context Efficiency + pagination-aware response bloat (closes #26)

### DIFF
--- a/src/mcp_quality/engines/cost.py
+++ b/src/mcp_quality/engines/cost.py
@@ -17,6 +17,7 @@ or not anything works (the mcp-xray insight, PRD §7.1). Fully offline & determi
 from __future__ import annotations
 
 import math
+from typing import Any
 
 from mcp_quality.engines.base import EngineBase, clamp
 from mcp_quality.models import FamilyScore, Finding, ProbeContext, Severity, ToolDef
@@ -35,6 +36,11 @@ PER_TOOL_BLOAT = 700
 REMEDIATION_THRESHOLD = 10_000
 # A single tool response heavier than this is flagged as response-bloat (REQ-$5).
 RESPONSE_BLOAT_TOKENS = 1_000
+# Params that let a caller bound a response — a big response with none of these is worse.
+_PAGINATION_PARAMS = {
+    "limit", "offset", "cursor", "page", "per_page", "page_size", "pagesize",
+    "page_token", "max_results", "maxresults", "count", "top", "after", "before",
+}
 # Penalty curve constants, anchored to the documented landmarks (see module docstring).
 _A, _B = 10.7, 1.8
 
@@ -155,6 +161,22 @@ class CostEngine(EngineBase):
             if counter_name.startswith("anthropic:")
             else "estimate (OpenAI tokenizer; undercounts Claude ~15-20%)"
         )
+        # #26: Context Efficiency headline — the schema tax (always paid) plus a
+        # representative response, so builders have one comparable per-server footprint.
+        context_efficiency: dict[str, Any] = {
+            "schema_tokens": toolset_tokens,
+            "response_tokens": "not measured",
+            "context_footprint": toolset_tokens,
+        }
+        if isinstance(response_tokens, dict) and response_tokens:
+            mean_response = round(sum(response_tokens.values()) / len(response_tokens))
+            context_efficiency["response_tokens"] = {
+                "mean": mean_response,
+                "max": max(response_tokens.values()),
+                "sampled_tools": len(response_tokens),
+            }
+            context_efficiency["context_footprint"] = toolset_tokens + mean_response
+
         metrics = {
             "toolset_tokens": toolset_tokens,
             "per_tool_tokens": dict(sorted(per_tool.items(), key=lambda kv: kv[1], reverse=True)),
@@ -164,6 +186,7 @@ class CostEngine(EngineBase):
             "counter_note": estimate_note,
             "tools": len(tools),
             "response_tokens": response_tokens,  # dict, or "not measured"
+            "context_efficiency": context_efficiency,
         }
         from mcp_quality.scoring import grade_for_score
 
@@ -200,18 +223,30 @@ class CostEngine(EngineBase):
                 continue
             out[t.name] = tokens
             if tokens > RESPONSE_BLOAT_TOKENS:
-                findings.append(
-                    Finding(
-                        family=self.name,
-                        code="$5-response-bloat",
-                        severity=Severity.LOW,
-                        tool=t.name,
-                        message=f"tool '{t.name}' returns ~{tokens} tokens per call — a large "
-                        "response tax on top of the schema tax",
-                        remediation="paginate, summarize, or let the caller select fields",
-                        evidence={"response_tokens": tokens},
+                props = set(map(str.lower, (t.input_schema or {}).get("properties", {})))
+                boundable = bool(props & _PAGINATION_PARAMS)
+                if boundable:
+                    findings.append(
+                        Finding(
+                            family=self.name, code="$5-response-bloat", severity=Severity.LOW,
+                            tool=t.name,
+                            message=f"tool '{t.name}' returns ~{tokens} tokens per call — large, "
+                            "though the caller can bound it via pagination",
+                            remediation="lower the default page size, or let the caller select fields",
+                            evidence={"response_tokens": tokens, "boundable": True},
+                        )
                     )
-                )
+                else:
+                    findings.append(
+                        Finding(
+                            family=self.name, code="$7-no-pagination", severity=Severity.MEDIUM,
+                            tool=t.name,
+                            message=f"tool '{t.name}' returns ~{tokens} tokens per call and has no "
+                            "pagination param — an unbounded response tax the caller can't cap",
+                            remediation=f"add a limit/cursor param; projected saving up to ~{tokens} tokens",
+                            evidence={"response_tokens": tokens, "boundable": False},
+                        )
+                    )
         return out
 
     @staticmethod

--- a/src/mcp_quality/report/render.py
+++ b/src/mcp_quality/report/render.py
@@ -170,6 +170,9 @@ def _family_headline(name: str, metrics: dict[str, Any]) -> str:
         return ""
     if name == "cost" and "toolset_tokens" in metrics:
         parts = [f"{metrics['toolset_tokens']} toolset tokens"]
+        ce = metrics.get("context_efficiency") or {}
+        if isinstance(ce.get("response_tokens"), dict):
+            parts.append(f"~{ce['context_footprint']} context footprint")
         if "usd_per_task" in metrics:
             parts.append(f"${metrics['usd_per_task']}/task")
         return "; ".join(parts)

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -131,7 +131,8 @@ async def test_response_bloat_sampled_when_opted_in():
     tools = [
         {"name": "get_small", "description": "read", "inputSchema": {"type": "object"},
          "annotations": {"readOnlyHint": True}},
-        {"name": "get_big", "description": "read", "inputSchema": {"type": "object"},
+        {"name": "get_big", "description": "read",
+         "inputSchema": {"type": "object", "properties": {"limit": {"type": "integer"}}},
          "annotations": {"readOnlyHint": True}},
     ]
     client = FakeClient(results={
@@ -142,4 +143,47 @@ async def test_response_bloat_sampled_when_opted_in():
     fs = await CostEngine(counter=HeuristicCounter()).run(ctx)
     rt = fs.metrics["response_tokens"]
     assert isinstance(rt, dict) and rt["get_big"] > rt["get_small"]
+    # get_big has a `limit` param → boundable → $5, not $7
     assert any(f.code == "$5-response-bloat" and f.tool == "get_big" for f in fs.findings)
+
+
+async def test_unbounded_big_response_flags_no_pagination():
+    # #26: a big response with NO pagination param is worse → $7-no-pagination.
+    from mcp_quality.connect.client import FakeClient, InvokeResult
+    from mcp_quality.engines.cost import CostEngine
+
+    tools = [{"name": "list_all", "description": "read", "inputSchema": {"type": "object"},
+              "annotations": {"readOnlyHint": True}}]
+    client = FakeClient(results={
+        "list_all": InvokeResult("list_all", False, content=[], structured={"rows": ["word " * 400] * 6}),
+    })
+    ctx = make_ctx(tools, client=client, config=ProbeConfig(response_bloat=True))
+    fs = await CostEngine(counter=HeuristicCounter()).run(ctx)
+    f = next((x for x in fs.findings if x.code == "$7-no-pagination"), None)
+    assert f is not None and f.tool == "list_all"
+    assert f.evidence["boundable"] is False
+    assert "projected saving" in f.remediation
+
+
+async def test_context_efficiency_metric_static():
+    from mcp_quality.engines.cost import CostEngine
+
+    tools = [{"name": "get_x", "description": "Return x.", "inputSchema": {"type": "object"}}]
+    fs = await CostEngine(counter=HeuristicCounter()).run(make_ctx(tools))
+    ce = fs.metrics["context_efficiency"]
+    assert ce["response_tokens"] == "not measured"
+    assert ce["context_footprint"] == ce["schema_tokens"] == fs.metrics["toolset_tokens"]
+
+
+async def test_context_efficiency_includes_response_when_sampled():
+    from mcp_quality.connect.client import FakeClient, InvokeResult
+    from mcp_quality.engines.cost import CostEngine
+
+    tools = [{"name": "get_x", "description": "read", "inputSchema": {"type": "object"},
+              "annotations": {"readOnlyHint": True}}]
+    client = FakeClient(results={"get_x": InvokeResult("get_x", False, content=[], structured={"v": "word " * 50})})
+    ctx = make_ctx(tools, client=client, config=ProbeConfig(response_bloat=True))
+    fs = await CostEngine(counter=HeuristicCounter()).run(ctx)
+    ce = fs.metrics["context_efficiency"]
+    assert isinstance(ce["response_tokens"], dict)
+    assert ce["context_footprint"] == ce["schema_tokens"] + ce["response_tokens"]["mean"]


### PR DESCRIPTION
Closes #26. Promotes runtime cost into a first-class **Context Efficiency** signal and makes response-bloat pagination-aware.

## What
- **Context Efficiency headline** — `cost.metrics.context_efficiency` = schema tokens (always paid) + a representative response (mean/max when sampled) → one comparable per-server `context_footprint`. Static mode: schema-only, response `"not measured"`.
- **Pagination-aware response bloat** — a large response now splits by whether the caller can bound it:
  - has a `limit`/`cursor`/… param → `$5-response-bloat` (LOW: "large but boundable").
  - **no** pagination param → `$7-no-pagination` (MEDIUM: "unbounded response tax the caller can't cap") with a projected token saving.
- Terminal headline shows the context footprint when responses were sampled.

Never affects the deterministic fast-path score (response sampling is opt-in via `--response-bloat`).

## Verified
- 4 new/updated unit tests (boundable vs unbounded split, static vs sampled footprint).
- **Live:** `bloated_server` → `schema 8,792 + mean response 14 = footprint 8,806` across 30 sampled tools. Full suite **159** green, ruff + mypy clean.

v0.3, branches off `main`.