### PR TITLE
feat(legibility): selection accuracy + over-triggering gate (closes #29)

### DIFF
--- a/src/mcp_quality/engines/legibility.py
+++ b/src/mcp_quality/engines/legibility.py
@@ -27,6 +27,17 @@ GOAL_TEMPLATES = (
     "Help me {intent}",
 )
 
+# Domain-agnostic prompts no MCP tool should handle — used to measure over-triggering
+# (a tool that fires on these is a false positive). Kept general so they're out-of-scope
+# for essentially any server.
+OUT_OF_SCOPE_PROMPTS = (
+    "What is the capital of France?",
+    "Write a haiku about the ocean.",
+    "What is 17 multiplied by 24?",
+    "Translate 'good morning' into Spanish.",
+    "Summarize the plot of Hamlet in one sentence.",
+)
+
 _LINT_PENALTY = {
     Severity.INFO: 0,
     Severity.LOW: 2,
@@ -88,16 +99,31 @@ class LegibilityEngine(EngineBase):
         top_confusion = probe["top_confusion"]
         mean_conf = probe["mean_confusion"]
 
+        false_fire_rate = probe.get("false_fire_rate", 0.0)
+
         # Build findings from the (possibly cached) probe data — no model calls here, so a
         # cache hit invokes the model zero times (REQ-L6).
         findings = list(lints) + self._findings_from_probe(probe)
+        if false_fire_rate > 0:
+            findings.append(
+                Finding(
+                    family=self.name, code="L6-over-triggering", severity=Severity.MEDIUM,
+                    message=f"tools fired on {false_fire_rate:.0%} of out-of-scope prompts "
+                    "(should have declined) — a spurious-call risk",
+                    remediation="tighten descriptions so tools don't look applicable to unrelated requests",
+                    evidence={"false_fire_rate": round(false_fire_rate, 3)},
+                )
+            )
 
-        base = selection_rate * (1 - mean_conf) * 100
+        # selection accuracy × (1 − confusion) × (1 − over-triggering) − lint penalty
+        base = selection_rate * (1 - mean_conf) * (1 - false_fire_rate) * 100
         score = clamp(base - lint_penalty)
         from mcp_quality.scoring import grade_for_score
 
         metrics = {
             "selection_rate": round(selection_rate, 3),
+            "selection_accuracy": round(selection_rate, 3),  # AST-matched right-tool rate (#29)
+            "false_fire_rate": round(false_fire_rate, 3),
             "top_confusion": top_confusion,
             "mean_confusion": round(mean_conf, 3),
             "model": model.model_id,
@@ -166,8 +192,17 @@ class LegibilityEngine(EngineBase):
         low_tools = [t for t, tot in per_tool_total.items()
                      if tot and (tot - sum(confusion[t].values())) / tot < 0.6]
 
+        # Over-triggering: out-of-scope prompts no tool should handle. A well-behaved
+        # server's tools decline; a fire is a false positive (#29).
+        fires = 0
+        for prompt in OUT_OF_SCOPE_PROMPTS:
+            if model.choose_tool(prompt, tool_pairs, allow_none=True):
+                fires += 1
+        false_fire_rate = fires / len(OUT_OF_SCOPE_PROMPTS)
+
         return {
             "selection_rate": selection_rate,
+            "false_fire_rate": false_fire_rate,
             "top_confusion": top_confusion,
             "mean_confusion": mean_conf,
             "low_tools": low_tools,

--- a/src/mcp_quality/legibility/model.py
+++ b/src/mcp_quality/legibility/model.py
@@ -12,6 +12,7 @@ execution — that is what makes it cheap and reliable on small models.
 
 from __future__ import annotations
 
+import re
 from typing import Protocol, runtime_checkable
 
 
@@ -22,8 +23,10 @@ class ModelProvider(Protocol):
     call_count: int
     is_canonical: bool
 
-    def choose_tool(self, goal: str, tools: list[tuple[str, str]]) -> str:
-        """Given a goal and (name, description) pairs, return the chosen tool name."""
+    def choose_tool(self, goal: str, tools: list[tuple[str, str]], *, allow_none: bool = False) -> str:
+        """Given a goal and (name, description) pairs, return the chosen tool name.
+        When ``allow_none``, the model may decline — return "" if no tool fits (used to
+        measure over-triggering on out-of-scope prompts)."""
         ...
 
     def propose_rewrite(self, name: str, description: str, confusers: list[str]) -> str:
@@ -46,14 +49,16 @@ class StubModel:
         self.seed = seed
         self.call_count = 0
 
-    def choose_tool(self, goal: str, tools: list[tuple[str, str]]) -> str:
+    def choose_tool(self, goal: str, tools: list[tuple[str, str]], *, allow_none: bool = False) -> str:
         self.call_count += 1
         pick = self._choices.get(goal)
         if callable(pick):
             return pick(goal, tools)
         if isinstance(pick, str):
             return pick
-        return tools[0][0] if tools else ""
+        # Unscripted: decline when allowed (a well-behaved model wouldn't fire), else
+        # fall back to the first tool (forced-choice selection probe).
+        return "" if allow_none else (tools[0][0] if tools else "")
 
     def propose_rewrite(self, name: str, description: str, confusers: list[str]) -> str:
         self.call_count += 1
@@ -85,6 +90,16 @@ _CHOOSE_PROMPT = (
     "Goal: {goal}\n\nTools:\n{tools}\n\n"
     "Reply with ONLY the exact name of the single best tool."
 )
+_CHOOSE_PROMPT_NONE = (
+    "You are an agent deciding which tool, if any, accomplishes a goal.\n"
+    "Goal: {goal}\n\nTools:\n{tools}\n\n"
+    "Reply with ONLY the exact name of the single best tool, or exactly NONE if no tool fits."
+)
+
+
+def _prompt_for(goal: str, listing: str, allow_none: bool) -> str:
+    tpl = _CHOOSE_PROMPT_NONE if allow_none else _CHOOSE_PROMPT
+    return tpl.format(goal=goal, tools=listing)
 
 
 class _OpenAICompatModel:
@@ -110,16 +125,16 @@ class _OpenAICompatModel:
             return OpenAI(base_url=self._base_url, api_key=os.environ.get("OPENAI_API_KEY", "local"))
         return OpenAI()
 
-    def choose_tool(self, goal: str, tools: list[tuple[str, str]]) -> str:
+    def choose_tool(self, goal: str, tools: list[tuple[str, str]], *, allow_none: bool = False) -> str:
         self.call_count += 1
         listing = "\n".join(f"- {n}: {d}" for n, d in tools)
         resp = self._client().chat.completions.create(
             model=self.model_id,
             temperature=0,
             seed=self.seed,
-            messages=[{"role": "user", "content": _CHOOSE_PROMPT.format(goal=goal, tools=listing)}],
+            messages=[{"role": "user", "content": _prompt_for(goal, listing, allow_none)}],
         )
-        return _match_name((resp.choices[0].message.content or "").strip(), tools)
+        return _match_name((resp.choices[0].message.content or "").strip(), tools, allow_none=allow_none)
 
     def propose_rewrite(self, name: str, description: str, confusers: list[str]) -> str:
         self.call_count += 1
@@ -146,15 +161,15 @@ class _AnthropicModel:
 
         return Anthropic()
 
-    def choose_tool(self, goal: str, tools: list[tuple[str, str]]) -> str:
+    def choose_tool(self, goal: str, tools: list[tuple[str, str]], *, allow_none: bool = False) -> str:
         self.call_count += 1
         listing = "\n".join(f"- {n}: {d}" for n, d in tools)
         msg = self._client().messages.create(
             model=self.model_id, max_tokens=32, temperature=0,
-            messages=[{"role": "user", "content": _CHOOSE_PROMPT.format(goal=goal, tools=listing)}],
+            messages=[{"role": "user", "content": _prompt_for(goal, listing, allow_none)}],
         )
         text = "".join(getattr(b, "text", "") for b in msg.content).strip()
-        return _match_name(text, tools)
+        return _match_name(text, tools, allow_none=allow_none)
 
     def propose_rewrite(self, name: str, description: str, confusers: list[str]) -> str:
         self.call_count += 1
@@ -167,12 +182,17 @@ class _AnthropicModel:
         return "".join(getattr(b, "text", "") for b in msg.content).strip()
 
 
-def _match_name(reply: str, tools: list[tuple[str, str]]) -> str:
-    """Map a model's free-text reply back to a real tool name (robust to chatter)."""
+def _match_name(reply: str, tools: list[tuple[str, str]], *, allow_none: bool = False) -> str:
+    """Map a model's free-text reply back to a real tool name (robust to chatter).
+    When ``allow_none``, an explicit decline or an unmatched reply → "" (no tool fired)."""
+    reply = reply.strip()
+    if allow_none and re.match(r"^(none|no tool|nothing|n/?a)\b", reply, re.I):
+        return ""
     names = [n for n, _ in tools]
     if reply in names:
         return reply
     for n in names:
         if n in reply:
             return n
-    return names[0] if names else ""
+    # Unmatched: with allow_none, treat as no-fire (don't fabricate a selection).
+    return "" if allow_none else (names[0] if names else "")

--- a/tests/test_over_triggering.py
+++ b/tests/test_over_triggering.py
@@ -1,0 +1,64 @@
+"""Over-triggering + selection-accuracy tests (issue #29)."""
+
+from __future__ import annotations
+
+from mcp_quality.config import ProbeConfig
+from mcp_quality.engines.legibility import (
+    OUT_OF_SCOPE_PROMPTS,
+    LegibilityEngine,
+    build_goals,
+)
+from mcp_quality.legibility.model import StubModel, _match_name
+
+from .conftest import make_ctx, make_surface
+
+TOOLS = [
+    {"name": "get_weather", "description": "Return weather for a city.", "inputSchema": {"type": "object"}},
+    {"name": "list_cities", "description": "List known cities.", "inputSchema": {"type": "object"}},
+]
+
+
+def _correct_choices():
+    return {g: gold for g, gold in build_goals(make_surface(TOOLS))}
+
+
+# -- _match_name allow_none -----------------------------------------------------
+
+def test_match_name_declines_on_none():
+    tools = [("get_weather", "x"), ("list_cities", "y")]
+    assert _match_name("NONE", tools, allow_none=True) == ""
+    assert _match_name("no tool fits here", tools, allow_none=True) == ""
+    assert _match_name("nothing relevant", tools, allow_none=True) == ""  # unmatched → no fire
+    assert _match_name("get_weather", tools, allow_none=True) == "get_weather"  # real fire
+    assert _match_name("unparseable", tools, allow_none=False) == "get_weather"  # forced-choice fallback
+
+
+# -- over-triggering probe ------------------------------------------------------
+
+async def test_no_over_triggering_when_tools_decline(tmp_path):
+    # unscripted out-of-scope prompts → StubModel declines (allow_none) → 0 false fires
+    stub = StubModel(choices=_correct_choices())
+    fs = await LegibilityEngine(model=stub).run(
+        make_ctx(TOOLS, config=ProbeConfig(cache_dir=str(tmp_path))))
+    assert fs.metrics["false_fire_rate"] == 0.0
+    assert not any(f.code == "L6-over-triggering" for f in fs.findings)
+
+
+async def test_over_triggering_detected_and_penalized(tmp_path):
+    choices = _correct_choices()
+    choices[OUT_OF_SCOPE_PROMPTS[0]] = "get_weather"  # fires on an unrelated prompt
+    stub = StubModel(choices=choices)
+    fs = await LegibilityEngine(model=stub).run(
+        make_ctx(TOOLS, config=ProbeConfig(cache_dir=str(tmp_path))))
+    assert fs.metrics["false_fire_rate"] == round(1 / len(OUT_OF_SCOPE_PROMPTS), 3)
+    l6 = next((f for f in fs.findings if f.code == "L6-over-triggering"), None)
+    assert l6 is not None
+    assert fs.score < 100  # the false fire pulled the score down
+
+
+async def test_selection_accuracy_metric_present(tmp_path):
+    stub = StubModel(choices=_correct_choices())
+    fs = await LegibilityEngine(model=stub).run(
+        make_ctx(TOOLS, config=ProbeConfig(cache_dir=str(tmp_path))))
+    assert fs.metrics["selection_accuracy"] == 1.0
+    assert fs.metrics["false_fire_rate"] == 0.0


### PR DESCRIPTION
Closes #29. Deepens Legibility with two distinct failure signals: picking the *wrong* tool, and firing *any* tool when none should.

## What
- **Selection accuracy** surfaced as `metrics.selection_accuracy` — deterministic structural (name) matching of the chosen call, no LLM judge.
- **Over-triggering probe** — a fixed set of domain-agnostic, out-of-scope prompts is run with the model *allowed to decline* (`choose_tool(..., allow_none=True)`); the fraction that still fire a tool is `metrics.false_fire_rate`, with an `L6-over-triggering` finding.
- Score now = `selection × (1 − confusion) × (1 − false_fire) − lint_penalty`.
- Model layer gained `allow_none` end-to-end (Protocol, StubModel, OpenAI-compatible, Anthropic) with a "reply NONE" prompt and decline-aware `_match_name`. Cached with the rest of the probe → warm reruns still invoke the model zero times.

## Verified
- Unit tests: decline parsing, clean vs detected over-triggering (+ score penalty), selection-accuracy metric.
- **Live (Xerberus tools, offline dump + Ollama):** `selection_accuracy 1.0 · false_fire_rate 0.0` — the model declined on all 5 out-of-scope prompts. Full suite **163** green, ruff + mypy clean.

v0.3, branches off `main`.