### PR TITLE
feat(snapshot): capability-stability / version-drift gate (closes #27)

### DIFF
--- a/src/mcp_quality/pipeline.py
+++ b/src/mcp_quality/pipeline.py
@@ -155,12 +155,14 @@ def _decide_exit(config: ProbeConfig, report: Report) -> ExitCode:
         fam = report.families.get(family)
         if fam and fam.measured and _GRADE_ORDER.get(fam.grade, 0) < _GRADE_ORDER.get(floor, 0):
             return ExitCode.GATE_FAILURE
-    # Gate 3: regressions vs snapshot.
+    # Gate 3: regressions vs snapshot — score drop, broken contract, removed tool, or a
+    # capability change (scope expansion / breaking schema) that defeats a prior approval.
     if config.no_regressions and report.regression is not None:
         reg = report.regression
         broke = bool(reg.get("broken_contracts"))
         dropped = any(v < 0 for v in reg.get("score_delta", {}).values())
-        if broke or dropped:
+        drift = bool(reg.get("capability_changes")) or bool(reg.get("removed_tools"))
+        if broke or dropped or drift:
             return ExitCode.GATE_FAILURE
     return ExitCode.OK
 

--- a/src/mcp_quality/snapshot/store.py
+++ b/src/mcp_quality/snapshot/store.py
@@ -29,11 +29,48 @@ def _hash(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
 
 
-def _tool_fingerprint(tool: ToolDef) -> dict[str, str]:
+def _tool_fingerprint(tool: ToolDef) -> dict[str, Any]:
+    """Per-tool fingerprint for drift detection (#27): content hashes + a capability
+    surface (declared safety + params) so we can catch silent scope/breaking changes."""
+    schema = tool.input_schema or {}
+    props = schema.get("properties") or {}
     return {
         "description_hash": _hash(tool.description or ""),
-        "schema_hash": _hash(json.dumps(tool.input_schema, sort_keys=True)),
+        "schema_hash": _hash(json.dumps(schema, sort_keys=True)),
+        "read_only": bool(tool.is_read_only),
+        "destructive": bool(tool.is_destructive),
+        "required": sorted(schema.get("required", []) or []),
+        "params": {k: (v.get("type") if isinstance(v, dict) else None) for k, v in props.items()},
     }
+
+
+def _capability_changes(name: str, old: dict[str, Any], new: dict[str, Any]) -> list[dict[str, str]]:
+    """Typed drift between two fingerprints of the same tool. Only flags changes that
+    widen scope or break existing callers; silent on additive/cosmetic changes."""
+    out: list[dict[str, str]] = []
+    # scope expansion — was declared safe, now isn't (the rug-pull tell). Only when the
+    # baseline recorded the flag (old-format snapshots omit it → skip, no false positive).
+    if "read_only" in old and old.get("read_only") and not new.get("read_only"):
+        out.append({"tool": name, "kind": "scope-expansion", "detail": "was read-only, now is not"})
+    if "destructive" in old and not old.get("destructive") and new.get("destructive"):
+        out.append({"tool": name, "kind": "scope-expansion", "detail": "now declares destructive"})
+    # breaking schema — new required fields / removed params / changed types break callers.
+    if "required" in old:
+        new_required = sorted(set(new.get("required", [])) - set(old.get("required", [])))
+        if new_required:
+            out.append({"tool": name, "kind": "breaking-schema",
+                        "detail": f"new required param(s): {', '.join(new_required)}"})
+    if "params" in old:
+        old_p, new_p = old.get("params", {}), new.get("params", {})
+        removed = sorted(set(old_p) - set(new_p))
+        if removed:
+            out.append({"tool": name, "kind": "breaking-schema",
+                        "detail": f"removed param(s): {', '.join(removed)}"})
+        for p in sorted(set(old_p) & set(new_p)):
+            if old_p[p] != new_p[p]:
+                out.append({"tool": name, "kind": "breaking-schema",
+                            "detail": f"param '{p}' type {old_p[p]} → {new_p[p]}"})
+    return out
 
 
 def build_snapshot(surface: ServerSurface, families: dict[str, FamilyScore]) -> dict[str, Any]:
@@ -67,14 +104,22 @@ class SnapshotDiff:
     added_tools: list[str] = field(default_factory=list)
     removed_tools: list[str] = field(default_factory=list)
     changed_tools: list[str] = field(default_factory=list)  # description or schema changed
+    capability_changes: list[dict[str, str]] = field(default_factory=list)  # typed drift (#27)
     broken_contracts: list[str] = field(default_factory=list)
     score_delta: dict[str, float] = field(default_factory=dict)  # per family (negative = worse)
     rubric_mismatch: bool = False
 
     @property
     def has_regression(self) -> bool:
-        """A regression = any negative score delta or any newly broken contract."""
-        return bool(self.broken_contracts) or any(d < 0 for d in self.score_delta.values())
+        """A regression = a newly broken contract, a negative score delta, a removed tool,
+        or a capability change (scope expansion / breaking schema) — the drift that
+        silently defeats a prior approval (#27)."""
+        return (
+            bool(self.broken_contracts)
+            or bool(self.removed_tools)
+            or bool(self.capability_changes)
+            or any(d < 0 for d in self.score_delta.values())
+        )
 
     def to_dict(self) -> dict[str, Any]:
         out: dict[str, Any] = {
@@ -87,6 +132,8 @@ class SnapshotDiff:
             out["added_tools"] = self.added_tools
         if self.removed_tools:
             out["removed_tools"] = self.removed_tools
+        if self.capability_changes:
+            out["capability_changes"] = self.capability_changes
         if self.rubric_mismatch:
             out["rubric_mismatch"] = True
         return out
@@ -109,8 +156,14 @@ def diff_against_baseline(
     diff.added_tools = sorted(set(new_tools) - set(old_tools))
     diff.removed_tools = sorted(set(old_tools) - set(new_tools))
     for name in sorted(set(old_tools) & set(new_tools)):
-        if old_tools[name] != new_tools[name]:
+        old_fp, new_fp = old_tools[name], new_tools[name]
+        # changed = semantic content (desc/schema) differs — stable across fingerprint-format
+        # upgrades, which add keys but don't change these two hashes.
+        if (old_fp.get("description_hash"), old_fp.get("schema_hash")) != (
+            new_fp["description_hash"], new_fp["schema_hash"]
+        ):
             diff.changed_tools.append(name)
+        diff.capability_changes.extend(_capability_changes(name, old_fp, new_fp))
 
     # Score deltas per family — only when rubric matches (else scores aren't comparable).
     if not diff.rubric_mismatch:

--- a/tests/test_capability_drift.py
+++ b/tests/test_capability_drift.py
@@ -1,0 +1,93 @@
+"""Capability-stability / version-drift tests (issue #27)."""
+
+from __future__ import annotations
+
+from mcp_quality.config import ProbeConfig
+from mcp_quality.connect.discover import surface_from_tools
+from mcp_quality.exit_codes import ExitCode
+from mcp_quality.models import FamilyScore
+from mcp_quality.pipeline import run_probe
+from mcp_quality.snapshot import build_snapshot, diff_against_baseline, write_snapshot
+
+_FAMS = {"cost": FamilyScore("cost", 100.0, "A")}
+
+
+def _diff(old_tools, new_tools):
+    baseline = build_snapshot(surface_from_tools(old_tools), _FAMS)
+    return diff_against_baseline(baseline, surface_from_tools(new_tools), _FAMS)
+
+
+def _tool(name, *, read_only=None, destructive=None, props=None, required=None, desc="d"):
+    ann = {}
+    if read_only is not None:
+        ann["readOnlyHint"] = read_only
+    if destructive is not None:
+        ann["destructiveHint"] = destructive
+    schema = {"type": "object", "properties": props or {}}
+    if required:
+        schema["required"] = required
+    return {"name": name, "description": desc, "inputSchema": schema, "annotations": ann}
+
+
+def _kinds(diff):
+    return {c["kind"] for c in diff.capability_changes}
+
+
+def test_scope_expansion_read_only_lost():
+    d = _diff([_tool("t", read_only=True)], [_tool("t", read_only=False)])
+    assert "scope-expansion" in _kinds(d)
+    assert d.has_regression
+
+
+def test_scope_expansion_became_destructive():
+    d = _diff([_tool("t", destructive=False)], [_tool("t", destructive=True)])
+    assert "scope-expansion" in _kinds(d)
+    assert d.has_regression
+
+
+def test_breaking_new_required_field():
+    d = _diff([_tool("t", props={"id": {"type": "string"}})],
+              [_tool("t", props={"id": {"type": "string"}}, required=["id"])])
+    assert "breaking-schema" in _kinds(d)
+    assert d.has_regression
+
+
+def test_breaking_removed_param():
+    d = _diff([_tool("t", props={"a": {"type": "string"}, "b": {"type": "string"}})],
+              [_tool("t", props={"a": {"type": "string"}})])
+    assert any("removed param" in c["detail"] for c in d.capability_changes)
+    assert d.has_regression
+
+
+def test_breaking_type_change():
+    d = _diff([_tool("t", props={"a": {"type": "string"}})],
+              [_tool("t", props={"a": {"type": "integer"}})])
+    assert any("type" in c["detail"] for c in d.capability_changes)
+
+
+def test_additive_optional_param_is_not_a_regression():
+    d = _diff([_tool("t", props={"a": {"type": "string"}})],
+              [_tool("t", props={"a": {"type": "string"}, "b": {"type": "string"}})])
+    assert d.capability_changes == []
+    assert not d.has_regression
+
+
+def test_removed_tool_is_a_regression():
+    d = _diff([_tool("t1"), _tool("t2")], [_tool("t1")])
+    assert d.removed_tools == ["t2"]
+    assert d.has_regression
+
+
+def test_added_tool_is_not_a_regression():
+    d = _diff([_tool("t1")], [_tool("t1"), _tool("t2")])
+    assert d.added_tools == ["t2"]
+    assert not d.has_regression
+
+
+async def test_no_regressions_gate_fails_on_scope_expansion(tmp_path):
+    snap = tmp_path / "snapshot.json"
+    write_snapshot(snap, build_snapshot(surface_from_tools([_tool("act", read_only=True)]), _FAMS))
+    cfg = ProbeConfig(families=("cost",), no_regressions=True, snapshot_path=str(snap))
+    outcome = await run_probe(cfg, surface=surface_from_tools([_tool("act", read_only=False)]))
+    assert outcome.report.regression["capability_changes"]
+    assert outcome.exit_code == ExitCode.GATE_FAILURE


### PR DESCRIPTION
Closes #27. The trust-over-time wedge: does a server that was vetted once *stay* vetted? Extends the snapshot engine to catch silent scope/breaking changes across versions.

## What
- **Capability fingerprint** per tool in the snapshot: content hashes **+** declared safety (`read_only`/`destructive`), `required` fields, and param types.
- **Typed drift detection** in the diff, distinct from score deltas:
  - `scope-expansion` — a tool that was `read_only` is no longer, or newly declares `destructive` (the rug-pull tell).
  - `breaking-schema` — new required param, removed param, or a param type change (breaks existing callers).
  - Additive/optional changes are intentionally **not** flagged.
- **`--no-regressions` now fails** on capability changes and removed tools (not just score drops / broken contracts); the `regression` block lists `capability_changes` separately.
- Backward-compatible with old-format snapshots (skips capability checks it can't compute — no false positives).

## Verified
- 9 unit tests (each drift class, additive-is-safe, removed/added tools, the pipeline gate).
- **Live:** snapshotted `good_server`, then ran a variant where `get_weather` gained a required `units` param → gate failed with `breaking-schema: new required param(s): units` (exit 1); the unchanged server passed (exit 0). Full suite **172** green, ruff + mypy clean.

v0.3, branches off `main`.