### PR TITLE
feat(reliability): pass^k reliability overlay (--reliability K)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ a commit silently breaks a tool or drops a score. `mcp-quality badge` emits an
 Overall score = a weighted, **versioned rubric**; measured families are renormalized, and
 an F in any family hard-gates the grade to C.
 
+### Reliability overlay — `--reliability K`
+
+Accuracy asks *"can it work?"*; reliability asks *"will it work **every** time?"* — the
+number a deploy gate actually cares about. `--reliability K` reruns the nondeterministic
+families K times and reports **pass^k**: the projected probability all K runs pass. A
+server that works 9 times in 10 is a 10% incident rate — pass^k over 5 runs is 59%, not an
+A. Deterministic families (Contract, Cost, Safety) short-circuit to 100% with no reruns, so
+the fast path stays free.
+
 ## Where it fits
 
 mcp-quality doesn't compete with the security scanners or the point tools — it unifies the

--- a/src/mcp_quality/cli.py
+++ b/src/mcp_quality/cli.py
@@ -112,6 +112,8 @@ def _add_family_flags(sp: argparse.ArgumentParser) -> None:
     )
     sp.add_argument("--seed", type=int, default=None)
     sp.add_argument("--concurrency", type=int, default=None)
+    sp.add_argument("--reliability", dest="reliability_k", type=int, default=None, metavar="K",
+                    help="rerun nondeterministic families K times, report pass^k consistency")
     sp.add_argument("--response-bloat", action="store_true",
                     help="sample read-only tool outputs to measure response token weight (REQ-$5)")
 
@@ -151,6 +153,7 @@ def _config_from_args(args: argparse.Namespace) -> ProbeConfig:
         "response_bloat": _true_or_none(getattr(args, "response_bloat", False)),
         "seed": getattr(args, "seed", None),
         "concurrency": getattr(args, "concurrency", None),
+        "reliability_k": getattr(args, "reliability_k", None),
         "families": _families_from_args(args) if hasattr(args, "all_families") else None,
     }
     if args.command == "run":

--- a/src/mcp_quality/config.py
+++ b/src/mcp_quality/config.py
@@ -44,6 +44,11 @@ class ProbeConfig:
     fail_under_family: dict[str, str] = field(default_factory=dict)  # per-family gates
     no_regressions: bool = False  # any family dropped vs snapshot → exit 1
 
+    # --- reliability overlay (#31) ---
+    # Run the nondeterministic families K times and report pass^k (consistency, not peak
+    # accuracy). K=1 → no reruns; deterministic families short-circuit to reliability 1.0.
+    reliability_k: int = 1
+
     # --- legibility ([llm]) ---
     model: str | None = None  # e.g. "ollama:qwen2.5-3b", "anthropic:claude-haiku-4-5"
     seed: int = 42

--- a/src/mcp_quality/engines/base.py
+++ b/src/mcp_quality/engines/base.py
@@ -38,6 +38,10 @@ class EngineBase:
     name: str = "base"
     requires_live: bool = False
     requires_llm: bool = False
+    # True → repeated runs on the same surface are byte-identical, so the reliability
+    # overlay (#31) short-circuits them to pass^k = 1.0 with no reruns. Families whose
+    # result can vary across runs (model sampling, live load timing) set this False.
+    deterministic: bool = True
 
     async def run(self, ctx: ProbeContext) -> FamilyScore:  # pragma: no cover - abstract
         raise NotImplementedError

--- a/src/mcp_quality/engines/legibility.py
+++ b/src/mcp_quality/engines/legibility.py
@@ -67,6 +67,7 @@ class LegibilityEngine(EngineBase):
     name = "legibility"
     requires_live = False
     requires_llm = True
+    deterministic = False  # model sampling varies across seeds → reliability overlay reruns it
 
     def __init__(self, model: ModelProvider | None = None) -> None:
         self._model = model

--- a/src/mcp_quality/engines/performance.py
+++ b/src/mcp_quality/engines/performance.py
@@ -41,6 +41,7 @@ class PerformanceEngine(EngineBase):
     name = "performance"
     requires_live = True
     requires_llm = False
+    deterministic = False  # live load timing varies run-to-run → reliability overlay reruns it
 
     def __init__(self, factory: Callable[[], Awaitable[Any]] | None = None) -> None:
         self._factory = factory

--- a/src/mcp_quality/models.py
+++ b/src/mcp_quality/models.py
@@ -291,6 +291,7 @@ class CheckEngine(Protocol):
     name: str
     requires_live: bool  # True → skipped/degraded in `static` mode (reported not-measured)
     requires_llm: bool  # True → off the CI-critical fast path (ADR-002)
+    deterministic: bool  # False → the reliability overlay reruns it K times (#31)
 
     async def run(self, ctx: ProbeContext) -> FamilyScore: ...
 

--- a/src/mcp_quality/pipeline.py
+++ b/src/mcp_quality/pipeline.py
@@ -51,8 +51,13 @@ async def run_probe(
             client, surface = await _connect(config)
             owns_client = True
 
+    reliability: dict[str, Any] | None = None
     try:
         families = await _run_engines(config, surface, client, trace)
+        # Reliability overlay: rerun the nondeterministic families and attach pass^k. Runs
+        # while the client is still open (live families rerun too), before the finally.
+        if getattr(config, "reliability_k", 1) > 1:
+            reliability = await _run_reliability_overlay(config, surface, client, trace, families)
     finally:
         if owns_client and client is not None:
             await client.close()
@@ -78,6 +83,7 @@ async def run_probe(
             "elapsed_s": round(time.monotonic() - started, 3),
             "mode": "static" if client is None else "live",
             "families_run": sorted(families),
+            **({"reliability": reliability} if reliability is not None else {}),
         },
     )
 
@@ -93,43 +99,107 @@ async def _connect(config: ProbeConfig) -> tuple[MCPClientProtocol, ServerSurfac
     return await connect(config)
 
 
+def _make_ctx(
+    config: ProbeConfig,
+    surface: ServerSurface,
+    client: MCPClientProtocol | None,
+    trace: TraceSink,
+    *,
+    seed: int,
+) -> ProbeContext:
+    # Build the legibility model provider from config (None → lints-only legibility). The
+    # seed is threaded here so the reliability overlay can vary it across trials.
+    from mcp_quality.legibility.model import build_model
+
+    return ProbeContext(
+        surface=surface,
+        config=config,
+        client=client,
+        model=build_model(getattr(config, "model", None), seed=seed),
+        trace=trace,
+    )
+
+
+async def _run_engine_once(
+    name: str, ctx: ProbeContext, client: MCPClientProtocol | None
+) -> FamilyScore:
+    """Run a single engine, degrading to not-measured rather than aborting the run."""
+    engine_cls = ENGINE_REGISTRY.get(name)
+    if engine_cls is None:
+        return FamilyScore.not_measured(name, "engine not available in this build")
+    engine = engine_cls()
+    # static mode: a live-only family can't be scored — report not-measured (ADR-006).
+    if client is None and name in LIVE_FAMILIES and engine.requires_live:
+        return FamilyScore.not_measured(name, "requires a live server (static mode)")
+    # LLM families decide for themselves whether they can run without a model — the
+    # Legibility engine still runs its offline lints and reports the behavioural part
+    # as partial rather than blanking the whole family.
+    try:
+        return await engine.run(ctx)
+    except Exception as exc:  # an engine crash degrades to not-measured, never aborts the run
+        return FamilyScore.not_measured(name, f"engine error: {exc!s}")
+
+
 async def _run_engines(
     config: ProbeConfig,
     surface: ServerSurface,
     client: MCPClientProtocol | None,
     trace: TraceSink,
 ) -> dict[str, FamilyScore]:
-    # Build the legibility model provider from config (None → lints-only legibility).
-    from mcp_quality.legibility.model import build_model
-
-    model = build_model(getattr(config, "model", None), seed=getattr(config, "seed", 42))
-
-    ctx = ProbeContext(
-        surface=surface,
-        config=config,
-        client=client,
-        model=model,
-        trace=trace,
-    )
+    ctx = _make_ctx(config, surface, client, trace, seed=getattr(config, "seed", 42))
 
     async def run_one(name: str) -> tuple[str, FamilyScore]:
-        engine_cls = ENGINE_REGISTRY.get(name)
-        if engine_cls is None:
-            return name, FamilyScore.not_measured(name, "engine not available in this build")
-        engine = engine_cls()
-        # static mode: a live-only family can't be scored — report not-measured (ADR-006).
-        if client is None and name in LIVE_FAMILIES and engine.requires_live:
-            return name, FamilyScore.not_measured(name, "requires a live server (static mode)")
-        # LLM families decide for themselves whether they can run without a model — the
-        # Legibility engine still runs its offline lints and reports the behavioural part
-        # as partial rather than blanking the whole family.
-        try:
-            return name, await engine.run(ctx)
-        except Exception as exc:  # an engine crash degrades to not-measured, never aborts the run
-            return name, FamilyScore.not_measured(name, f"engine error: {exc!s}")
+        return name, await _run_engine_once(name, ctx, client)
 
     pairs = await asyncio.gather(*(run_one(name) for name in config.families))
     return dict(pairs)
+
+
+async def _run_reliability_overlay(
+    config: ProbeConfig,
+    surface: ServerSurface,
+    client: MCPClientProtocol | None,
+    trace: TraceSink,
+    families: dict[str, FamilyScore],
+) -> dict[str, Any]:
+    """Rerun the nondeterministic, measured families K times and attach pass^k to each.
+
+    Deterministic families short-circuit to reliability 1.0/0.0 with no extra runs (the
+    whole fast path costs nothing). The portfolio reliability is the product of the
+    per-family rates: a full run only passes if *every* measured family passes.
+    """
+    from mcp_quality.scoring.reliability import family_passed, reliability_metrics
+
+    k = config.reliability_k
+    per_family: dict[str, dict[str, Any]] = {}
+    for name, fs in families.items():
+        if not fs.measured:
+            continue
+        engine_cls = ENGINE_REGISTRY.get(name)
+        deterministic = getattr(engine_cls, "deterministic", True) if engine_cls else True
+        passes = int(family_passed(fs))  # the primary run counts as trial #1
+        if deterministic:
+            metrics = reliability_metrics(passes, 1)
+        else:
+            for i in range(1, k):  # k-1 more trials, each with a fresh seed
+                ctx = _make_ctx(config, surface, client, trace, seed=getattr(config, "seed", 42) + i)
+                trial = await _run_engine_once(name, ctx, client)
+                passes += int(family_passed(trial))
+            metrics = reliability_metrics(passes, k)
+        fs.metrics["reliability"] = metrics
+        per_family[name] = metrics
+
+    overall_rate = 1.0
+    overall_phk = 1.0
+    for m in per_family.values():
+        overall_rate *= float(m["pass_rate"])
+        overall_phk *= float(m["pass_hat_k"])
+    return {
+        "k": k,
+        "overall_pass_rate": round(overall_rate, 4),
+        "overall_pass_hat_k": round(overall_phk, 4),
+        "per_family": {n: m["pass_hat_k"] for n, m in per_family.items()},
+    }
 
 
 def _apply_snapshot(

--- a/src/mcp_quality/report/render.py
+++ b/src/mcp_quality/report/render.py
@@ -100,6 +100,8 @@ def render_terminal(report: Report, *, console: Console | None = None) -> str:
             if f.remediation:
                 con.print(Text(f"      ↳ {f.remediation}", style="dim"))
 
+    _render_reliability(con, report)
+
     out = buffer.getvalue()
 
     # The disambiguation matrix goes last — the headline artifact when legibility ran.
@@ -152,6 +154,43 @@ def render_confusion_matrix(metrics: dict[str, Any], *, console: Console | None 
     if console is not None:
         console.print(out, end="")
     return out
+
+
+def _reliability_style(rate: float) -> str:
+    if rate >= 0.99:
+        return "green"
+    if rate >= 0.8:
+        return "yellow"
+    return "bold red"
+
+
+def _render_reliability(con: Console, report: Report) -> None:
+    """The pass^k overlay (#31): projected probability every family passes K runs in a row.
+    Only the flaky families (pass^k < 100%) are listed — a clean run just shows 'consistent'."""
+    rel = report.meta.get("reliability")
+    if not rel or rel.get("k", 1) <= 1:
+        return
+    k = rel["k"]
+    overall = float(rel.get("overall_pass_hat_k", 0.0))
+    con.print(Text(f"\nReliability  (pass^k over k={k} runs)", style=f"bold {OXBLOOD}"))
+    con.print(
+        Text.assemble(
+            ("  overall  ", "white"),
+            (f"{overall:.0%}", _reliability_style(overall)),
+            (f"   (per-run {float(rel.get('overall_pass_rate', 0.0)):.0%})", "dim"),
+        )
+    )
+    flaky = {n: v for n, v in rel.get("per_family", {}).items() if float(v) < 0.99}
+    for name, phk in sorted(flaky.items(), key=lambda kv: kv[1]):
+        con.print(
+            Text.assemble(
+                (f"    {name:<12} ", "cyan"),
+                (f"{float(phk):.0%}", _reliability_style(float(phk))),
+                ("  flaky — inconsistent across runs", "dim"),
+            )
+        )
+    if not flaky:
+        con.print(Text("    all families consistent across runs", style="dim"))
 
 
 def _severity_style(name: str) -> str:

--- a/src/mcp_quality/scoring/reliability.py
+++ b/src/mcp_quality/scoring/reliability.py
@@ -1,0 +1,47 @@
+"""The pass^k reliability overlay — consistency, not peak accuracy (#31).
+
+A server that passes 9 runs in 10 is a 10% incident rate in production. Accuracy answers
+"can it work?"; reliability answers "will it work *every* time?" — the number a team
+gating deploys on actually cares about. This module holds the *pure math*: whether a
+single family run passed, and the pass^k projection over K trials. The pipeline owns the
+reruns (it needs the engines and a live client); everything here is a pure function of
+counts, so it is trivially testable and deterministic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp_quality.models import FamilyScore
+
+# A run "passes" if the family was measured and did not fail outright. F (including a
+# hard-gate that caps the score into the F band) is the failing grade; A–D count as a
+# pass for consistency purposes — the overlay measures *repeatability*, not peak grade.
+PASS_GRADES = frozenset({"A", "B", "C", "D"})
+
+
+def family_passed(fs: FamilyScore) -> bool:
+    """True when this single run counts as a success for reliability accounting."""
+    return fs.measured and fs.grade in PASS_GRADES
+
+
+def pass_hat_k(passes: int, trials: int) -> float:
+    """The pass^k projection: (empirical per-call pass rate) ** trials — the probability
+    that K independent calls all succeed. Collapses to 1.0 iff every trial passed and
+    drops sharply otherwise (0.8 over 5 trials → 0.33), which is the whole point: a family
+    that flakes even once is not safe to depend on K times in a row."""
+    if trials <= 0:
+        return 0.0
+    rate = passes / trials
+    return rate**trials
+
+
+def reliability_metrics(passes: int, trials: int) -> dict[str, Any]:
+    """The per-family reliability record attached to ``FamilyScore.metrics['reliability']``."""
+    rate = passes / trials if trials else 0.0
+    return {
+        "trials": trials,
+        "passes": passes,
+        "pass_rate": round(rate, 4),
+        "pass_hat_k": round(pass_hat_k(passes, trials), 4),
+    }

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -1,0 +1,147 @@
+"""pass^k reliability overlay tests (issue #31) — the math, the short-circuit, the reruns."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_quality import pipeline
+from mcp_quality.config import ProbeConfig
+from mcp_quality.connect.discover import surface_from_tools
+from mcp_quality.engines.base import EngineBase
+from mcp_quality.models import FamilyScore
+from mcp_quality.pipeline import run_probe
+from mcp_quality.scoring.reliability import family_passed, pass_hat_k, reliability_metrics
+from mcp_quality.trace import TraceSink
+
+GOOD = [
+    {"name": "get_x", "description": "Return x. Example: get_x().", "inputSchema": {"type": "object"},
+     "annotations": {"readOnlyHint": True}},
+]
+
+
+def _surface(tools):
+    return surface_from_tools(tools)
+
+
+# -- pure pass^k math ----------------------------------------------------------
+
+def test_pass_hat_k_all_pass_is_one():
+    assert pass_hat_k(5, 5) == 1.0
+
+
+def test_pass_hat_k_one_flake_drops_sharply():
+    assert pass_hat_k(4, 5) == pytest.approx(0.8**5)  # a single flake in 5 → 0.33
+
+
+def test_pass_hat_k_never_passes_is_zero():
+    assert pass_hat_k(0, 3) == 0.0
+
+
+def test_pass_hat_k_deterministic_single_trial():
+    assert pass_hat_k(1, 1) == 1.0
+    assert pass_hat_k(0, 1) == 0.0
+
+
+def test_pass_hat_k_zero_trials_is_zero():
+    assert pass_hat_k(1, 0) == 0.0
+
+
+def test_reliability_metrics_shape():
+    assert reliability_metrics(3, 4) == {
+        "trials": 4, "passes": 3, "pass_rate": 0.75, "pass_hat_k": round(0.75**4, 4),
+    }
+
+
+def test_family_passed_predicate():
+    assert family_passed(FamilyScore("x", 90.0, "A"))
+    assert family_passed(FamilyScore("x", 62.0, "D"))
+    assert not family_passed(FamilyScore("x", 10.0, "F"))
+    assert not family_passed(FamilyScore.not_measured("x"))
+
+
+# -- overlay behaviour (fake engines) -----------------------------------------
+
+class _FlakyEngine(EngineBase):
+    name = "flaky"
+    deterministic = False
+    calls = 0
+
+    async def run(self, ctx):
+        type(self).calls += 1
+        passed = type(self).calls % 2 == 1  # calls 1,3 pass; 2,4 fail
+        return FamilyScore("flaky", 100.0 if passed else 10.0, "A" if passed else "F")
+
+
+class _DetEngine(EngineBase):
+    name = "det"
+    deterministic = True
+    calls = 0
+
+    async def run(self, ctx):
+        type(self).calls += 1
+        return FamilyScore("det", 100.0, "A")
+
+
+async def test_nondeterministic_family_reruns_k_times(monkeypatch):
+    _FlakyEngine.calls = 0
+    monkeypatch.setitem(pipeline.ENGINE_REGISTRY, "flaky", _FlakyEngine)
+    surface, trace = _surface(GOOD), TraceSink(run_id="t")
+    cfg = ProbeConfig(families=("flaky",), reliability_k=4)
+
+    ctx = pipeline._make_ctx(cfg, surface, None, trace, seed=42)
+    primary = await pipeline._run_engine_once("flaky", ctx, None)  # trial #1 → pass
+    families = {"flaky": primary}
+    rel = await pipeline._run_reliability_overlay(cfg, surface, None, trace, families)
+
+    # calls: 1 pass (primary) + 2 fail, 3 pass, 4 fail (reruns) → 2 passes of 4 trials
+    assert _FlakyEngine.calls == 4
+    assert families["flaky"].metrics["reliability"] == {
+        "trials": 4, "passes": 2, "pass_rate": 0.5, "pass_hat_k": round(0.5**4, 4),
+    }
+    assert rel["k"] == 4 and rel["overall_pass_rate"] == 0.5
+
+
+async def test_deterministic_family_short_circuits(monkeypatch):
+    _DetEngine.calls = 0
+    monkeypatch.setitem(pipeline.ENGINE_REGISTRY, "det", _DetEngine)
+    surface, trace = _surface(GOOD), TraceSink(run_id="t")
+    cfg = ProbeConfig(families=("det",), reliability_k=5)
+
+    ctx = pipeline._make_ctx(cfg, surface, None, trace, seed=42)
+    primary = await pipeline._run_engine_once("det", ctx, None)  # the only run
+    families = {"det": primary}
+    await pipeline._run_reliability_overlay(cfg, surface, None, trace, families)
+
+    assert _DetEngine.calls == 1  # NO reruns despite reliability_k=5
+    assert families["det"].metrics["reliability"] == {
+        "trials": 1, "passes": 1, "pass_rate": 1.0, "pass_hat_k": 1.0,
+    }
+
+
+# -- end-to-end through the real pipeline --------------------------------------
+
+async def test_fast_path_reliability_is_trivial_and_carried_in_meta():
+    cfg = ProbeConfig(families=("contract", "cost"), reliability_k=3)
+    outcome = await run_probe(cfg, surface=_surface(GOOD))
+    rel = outcome.report.meta["reliability"]
+    assert rel["k"] == 3
+    assert rel["overall_pass_rate"] == 1.0 and rel["overall_pass_hat_k"] == 1.0
+    # deterministic families ran exactly once (trials == 1), not three times.
+    for fam in ("contract", "cost"):
+        assert outcome.report.families[fam].metrics["reliability"]["trials"] == 1
+
+
+async def test_k_of_one_adds_no_reliability_block():
+    cfg = ProbeConfig(families=("contract", "cost"))  # reliability_k defaults to 1
+    outcome = await run_probe(cfg, surface=_surface(GOOD))
+    assert "reliability" not in outcome.report.meta
+    assert "reliability" not in outcome.report.families["cost"].metrics
+
+
+# -- CLI wiring ----------------------------------------------------------------
+
+def test_cli_reliability_flag_parses():
+    from mcp_quality.cli import build_parser
+
+    args = build_parser().parse_args(["run", "some-cmd", "--reliability", "5"])
+    assert args.reliability_k == 5


### PR DESCRIPTION
Closes #31.

## What

A cross-cutting **reliability overlay**: `--reliability K` reruns the *nondeterministic* families K times and reports **pass^k** — the projected probability that all K runs pass — as a number distinct from the accuracy grade.

Accuracy answers *"can it work?"*. Reliability answers *"will it work **every** time?"* — which is the number a deploy gate actually cares about. A server that passes 9 runs in 10 is a 10% incident rate; its pass^k over 5 runs is 59%, not an A.

## How it works
- **`pass^k` = (empirical per-run pass rate) ^ K.** Collapses to 1.0 iff every trial passed; drops sharply on a single flake (0.8 over 5 → 0.33). Pure math in `scoring/reliability.py`.
- A run "passes" if the family was measured and graded A–D (F, including a hard-gate cap into the F band, is a fail).
- **Deterministic families short-circuit.** Engines carry a `deterministic` flag (default `True`). Contract/Cost/Safety/Security are byte-identical across runs → reliability 1.0 with **zero reruns**, so the fast path stays free. Only Legibility (model sampling) and Performance (live load timing) are marked `deterministic = False` and actually rerun — each trial with a fresh seed to surface real variation.
- **Portfolio reliability** = product of per-family rates: a full run only passes if *every* family passes.
- Pure reporting overlay over reruns — engines stay pure functions (ADR-001); the pipeline (an allowed aggregator) does the reruns and annotates `FamilyScore.metrics['reliability']` + `report.meta['reliability']`.

At `K=1` (the default) nothing reruns and no reliability block is emitted — the fast-path JSON stays byte-identical, so the determinism guard is unaffected.

## Output
```
Reliability  (pass^k over k=3 runs)
  overall  100%   (per-run 100%)
    all families consistent across runs
```
JSON:
```json
"reliability": { "k": 3, "overall_pass_rate": 1.0, "overall_pass_hat_k": 1.0,
                 "per_family": { "contract": 1.0, "cost": 1.0 } }
```

## Tests / e2e
- `tests/test_reliability.py` (12 tests): pass^k math, `reliability_metrics` shape, the pass/fail predicate, a `_FlakyEngine` proving K reruns + fractional pass^k (2/4 → 0.5^4), a `_DetEngine` proving the deterministic short-circuit (calls==1 despite `--reliability 5`), end-to-end through `run_probe`, and the K=1 no-op.
- Live e2e: `mcp-quality run <good_server> --reliability 3` renders the overlay and short-circuits deterministic families (`trials: 1`).
- Full gate green: 194 passed, mypy clean, ruff clean.

## Docs
- README: new "Reliability overlay — `--reliability K`" section.