### PR TITLE
feat(contract): 2026-07-28 stateless-conformance checks (C12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ a commit silently breaks a tool or drops a score. `mcp-quality badge` emits an
 
 | Family | What it measures | Path |
 |--------|------------------|------|
-| **Contract** | JSON-RPC/handshake conformance, schema validity, output conformance, determinism & error-path/recovery probes, snapshot & version-drift regression | zero-LLM |
+| **Contract** | JSON-RPC/handshake conformance, schema validity, output conformance, determinism & error-path/recovery probes, 2026-07-28 stateless-conformance, snapshot & version-drift regression | zero-LLM |
 | **Cost** | token weight of your whole toolset, per-tool bloat (leave-one-out), runtime response bloat, Context Efficiency, $-per-task | zero-LLM |
 | **Legibility** *(the differentiator)* | agent-comprehension score, the **disambiguation matrix**, selection accuracy + over-triggering, description lints — with proposed rewrites you can auto-PR | small model |
 | **Performance** | concurrent-agent load with *real MCP semantics* (not naive HTTP), p50/p95/p99, max concurrency, connection-leak detection | live |

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -41,6 +41,17 @@ right. The `ConnectRecord.stateless_discover_ok` field is already present, so th
 drops in when the RC finalises and the SDK exposes it. The forward-compat lint (REQ-C10)
 still fires for legacy/SSE-only transports today.
 
+**Update (#32) — black-box stateless-conformance grading shipped.** We now grade the
+`2026-07-28` transition version-aware, requiring neither path (`contract/stateless.py`,
+codes `C12-*`). The signals the SDK *can't* give us (`server/discover`, `_meta`
+enforcement) stay `None` = not measured, never fabricated — so a legacy server gets a
+gentle `C10` nudge, a server that *negotiates* the stateless revision but breaks its rules
+gets a real `C12` finding. The one rule we *can* verify black-box today — `tools/list`
+identical across two fresh connections — is probed live in `transport.py`
+(`_probe_tools_list_stability`, best-effort → `None` on any failure) and carries a bounded
+score penalty when it comes back `False`. `stateless_readiness` rides in the Contract
+metrics.
+
 ## D3 — Offline token counter falls back to a deterministic heuristic
 
 **Spec:** REQ-$4 wants authoritative counts via a provider `count_tokens` and a

--- a/src/mcp_quality/connect/client.py
+++ b/src/mcp_quality/connect/client.py
@@ -28,6 +28,10 @@ class ConnectRecord:
     stateless_discover_ok: bool | None = None  # newer `server/discover` + _meta path, if any
     server_info: dict[str, Any] = field(default_factory=dict)
     capabilities: dict[str, Any] = field(default_factory=dict)
+    # 2026-07-28 (stateless) conformance signals (#32). None = not measured (never fabricated).
+    supported_versions: list[str] = field(default_factory=list)
+    tools_list_stable: bool | None = None  # identical tools/list across two fresh connections
+    meta_enforced: bool | None = None  # server rejects requests missing required _meta
 
 
 @dataclass

--- a/src/mcp_quality/connect/transport.py
+++ b/src/mcp_quality/connect/transport.py
@@ -9,7 +9,9 @@ determinism probe calls a tool twice; Performance hammers it), and unwound once 
 Handshake reality check: the current SDK negotiates via ``initialize`` and reports the
 server's ``protocolVersion``. There is no ``server/discover`` method in the SDK, so the
 "stateless discovery" path from the design doc is left unprobed (``stateless_discover_ok
-= None``) rather than fabricated — we grade what the protocol actually does.
+= None``) rather than fabricated — we grade what the protocol actually does. The one
+stateless-conformance rule we *can* check black-box today (#32) is ``tools/list``
+stability across two fresh connections — done with a second, short-lived session.
 """
 
 from __future__ import annotations
@@ -95,10 +97,36 @@ async def connect(config: ProbeConfig) -> tuple[MCPClient, ServerSurface]:
             capabilities=_dump(getattr(init, "capabilities", {})) or {},
         )
         surface = await _discover(session, record)
+        # #32: stateless-conformance — is tools/list identical on a second fresh connection?
+        record.tools_list_stable = await _probe_tools_list_stability(
+            config, transport, surface.surface_hash
+        )
         return MCPClient(session, stack, record), surface
     except Exception:
         await stack.aclose()
         raise
+
+
+async def _probe_tools_list_stability(
+    config: ProbeConfig, transport: Transport, first_hash: str
+) -> bool | None:
+    """Open a *second* fresh connection and compare tools/list to the first (#32).
+
+    Per-connection variance means an agent's tool set depends on which connection it opened
+    — a stateless-conformance bug. Best-effort and isolated: any failure (server can't take a
+    second connection, transport quirk) returns ``None`` = not measured, never a false alarm."""
+    stack = AsyncExitStack()
+    try:
+        read, write = await _open_streams(stack, transport, config)
+        session = await stack.enter_async_context(ClientSession(read, write))
+        await asyncio.wait_for(session.initialize(), timeout=config.stdio_timeout)
+        tools = await _list_all(session.list_tools, "tools")
+        second = surface_from_tools([_dump(t) for t in tools])
+        return second.surface_hash == first_hash
+    except Exception:
+        return None
+    finally:
+        await stack.aclose()
 
 
 async def _open_streams(stack: AsyncExitStack, transport: Transport, config: ProbeConfig):

--- a/src/mcp_quality/contract/stateless.py
+++ b/src/mcp_quality/contract/stateless.py
@@ -1,0 +1,98 @@
+"""2026-07-28 (stateless) conformance grading (#32) — pure, version-aware, black-box.
+
+The MCP spec is mid-transition. The 2026-07-28 revision drops the ``initialize`` /
+``initialized`` handshake and session IDs, makes ``server/discover`` mandatory, requires
+per-request ``_meta``, and forbids ``tools/list`` from varying per connection. Servers are
+still catching up, so we **grade the transition, require neither path**: a legacy server
+gets a gentle forward-compat nudge, not a failure; a server that *claims* the stateless
+revision but breaks its rules gets a real finding.
+
+This module is pure — it takes the signals the transport managed to observe (each a
+tri-state: True / False / None-for-not-measured) and returns findings + a readiness map.
+The transport (the only SDK-aware module) fills the signals in as far as the SDK allows;
+anything it can't probe stays ``None`` and is reported "not measured", never zeroed
+(ADR-006). That keeps the grader trivially testable with crafted records — no live server.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp_quality.models import Finding, Severity
+
+# The first spec revision that mandates the stateless (server/discover + _meta) path.
+STATELESS_REVISION = "2026-07-28"
+
+
+def on_stateless_revision(protocol_version: str) -> bool:
+    """ISO-date protocol versions compare lexicographically, so a string ``>=`` is correct."""
+    return bool(protocol_version) and protocol_version >= STATELESS_REVISION
+
+
+def _f(code: str, sev: Severity, message: str, remediation: str, **evidence: Any) -> Finding:
+    return Finding(
+        family="contract", code=code, severity=sev, message=message,
+        remediation=remediation, evidence=evidence or {},
+    )
+
+
+def grade_stateless_conformance(
+    protocol_version: str,
+    *,
+    discover_ok: bool | None = None,
+    tools_list_stable: bool | None = None,
+    meta_enforced: bool | None = None,
+    supported_versions: list[str] | None = None,
+) -> tuple[list[Finding], dict[str, Any]]:
+    """Grade stateless-readiness from observed signals. Returns (findings, readiness).
+
+    Each signal is tri-state: ``True`` observed-good, ``False`` observed-bad, ``None`` not
+    measured. Findings scale with intent: a server *on* the stateless revision that breaks a
+    rule earns a real (MEDIUM) finding; a legacy server merely gets forward-compat guidance.
+    """
+    findings: list[Finding] = []
+    stateless = on_stateless_revision(protocol_version)
+
+    # server/discover — mandatory on the stateless revision; optional (nice-to-have) before it.
+    if discover_ok is False:
+        if stateless:
+            findings.append(_f(
+                "C12-no-server-discover", Severity.MEDIUM,
+                f"negotiated {protocol_version} (stateless) but server/discover is not implemented",
+                "implement server/discover — it is required by the 2026-07-28 revision",
+                protocol_version=protocol_version,
+            ))
+        else:
+            findings.append(_f(
+                "C10-forward-compat", Severity.LOW,
+                "server/discover is not implemented (optional today, required by 2026-07-28)",
+                "adopt the stateless server/discover path when your SDK ships it",
+                protocol_version=protocol_version,
+            ))
+
+    # tools/list stability — a genuine bug on ANY revision: per-connection variance means an
+    # agent's tool set depends on which connection it happened to open.
+    if tools_list_stable is False:
+        findings.append(_f(
+            "C12-tools-list-unstable", Severity.MEDIUM,
+            "tools/list differs across two fresh connections — the surface is per-connection",
+            "return an identical tool list on every connection (no per-session leakage)",
+        ))
+
+    # _meta enforcement — only a finding when the server is on the revision that requires it.
+    if meta_enforced is False and stateless:
+        findings.append(_f(
+            "C12-meta-unenforced", Severity.LOW,
+            f"negotiated {protocol_version} but requests missing required _meta were accepted",
+            "reject requests missing required _meta fields per the stateless revision",
+        ))
+
+    readiness: dict[str, Any] = {
+        "protocol_version": protocol_version or None,
+        "on_stateless_revision": stateless,
+        "server_discover": discover_ok,
+        "tools_list_stable": tools_list_stable,
+        "meta_enforced": meta_enforced,
+        "supported_versions": supported_versions or [],
+    }
+    return findings, readiness

--- a/src/mcp_quality/engines/contract.py
+++ b/src/mcp_quality/engines/contract.py
@@ -22,6 +22,7 @@ from mcp_quality.contract.schema import (
     validate_against,
     validate_schema,
 )
+from mcp_quality.contract.stateless import grade_stateless_conformance
 from mcp_quality.engines.base import EngineBase, clamp
 from mcp_quality.models import FamilyScore, Finding, ProbeContext, Severity, ToolDef
 
@@ -50,6 +51,18 @@ class ContractEngine(EngineBase):
         tools = ctx.surface.tools
 
         self._check_handshake(ctx, findings)  # REQ-C1, C2, C10 (from the connect record)
+
+        # REQ-C10/C12 (#32): stateless (2026-07-28) conformance — version-aware, black-box.
+        # Works static too (reports what it can from the surface's negotiated version).
+        rec = getattr(ctx.client, "connect_record", None)
+        sl_findings, stateless_readiness = grade_stateless_conformance(
+            rec.protocol_version if rec else ctx.surface.protocol_version,
+            discover_ok=rec.stateless_discover_ok if rec else None,
+            tools_list_stable=rec.tools_list_stable if rec else None,
+            meta_enforced=rec.meta_enforced if rec else None,
+            supported_versions=rec.supported_versions if rec else None,
+        )
+        findings.extend(sl_findings)
 
         # REQ-C3: schema validity of every tool (static-ok).
         schema_invalid: set[str] = set()
@@ -118,6 +131,11 @@ class ContractEngine(EngineBase):
         if mean_affordance is not None:
             score = clamp(score - min(15.0, (100 - mean_affordance) * 0.15))
 
+        # #32: an unstable tools/list (per-connection surface) is a real defect — bounded,
+        # deterministic penalty. Non-adoption of the stateless path is only reported, not scored.
+        if stateless_readiness.get("tools_list_stable") is False:
+            score = clamp(score - 10.0)
+
         hard_gate = (
             bool(schema_invalid)
             or conformance_breaks > 0
@@ -162,6 +180,7 @@ class ContractEngine(EngineBase):
                 "skipped_writes": skipped_writes,
                 "invocation_measured": measured_live,
                 "protocol_version": ctx.surface.protocol_version,
+                "stateless_readiness": stateless_readiness,
                 "summary": summary,
             },
         )
@@ -277,7 +296,8 @@ class ContractEngine(EngineBase):
                     evidence={"errors": rec.framing_errors},
                 )
             )
-        # REQ-C10: forward-compat lint — flag transition risks.
+        # REQ-C10: transport forward-compat lint. The stateless (server/discover, _meta,
+        # tools/list-stability) checks are graded separately in grade_stateless_conformance.
         if rec.transport == "sse":
             findings.append(
                 Finding(
@@ -287,16 +307,5 @@ class ContractEngine(EngineBase):
                     message="server uses the deprecated HTTP+SSE transport",
                     remediation="migrate to Streamable HTTP (SSE was deprecated in the 2025-03-26 spec)",
                     evidence={"transport": "sse"},
-                )
-            )
-        elif rec.stateless_discover_ok is False and rec.legacy_handshake_ok:
-            findings.append(
-                Finding(
-                    family=self.name,
-                    code="C10-forward-compat",
-                    severity=Severity.LOW,
-                    message="server speaks only the legacy initialize handshake",
-                    remediation="adopt the stateless server/discover path when your SDK ships it",
-                    evidence={"protocol_version": rec.protocol_version},
                 )
             )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -65,6 +65,16 @@ async def test_e2e_error_path_clean_on_good_server():
     assert aff is not None and 0 <= aff <= 100
 
 
+async def test_e2e_stateless_tools_list_stable_on_good_server():
+    # #32: the transport opens a second fresh connection; a well-behaved server returns an
+    # identical tools/list, so the black-box stability probe measures True (no C12 finding).
+    cfg = ProbeConfig(target=_target("good_server.py"), families=("contract",))
+    outcome = await run_probe(cfg)
+    readiness = outcome.report.families["contract"].metrics["stateless_readiness"]
+    assert readiness["tools_list_stable"] is True
+    assert not any(f.code == "C12-tools-list-unstable" for f in outcome.report.all_findings())
+
+
 async def test_e2e_7_static_mode_not_measured():
     dump = SERVERS / "dump.mcp.json"
     cfg = ProbeConfig(static_path=str(dump), families=("contract", "cost"))

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -1,0 +1,114 @@
+"""2026-07-28 stateless-conformance tests (issue #32) — version-aware, black-box grading."""
+
+from __future__ import annotations
+
+from mcp_quality.connect.client import ConnectRecord, FakeClient
+from mcp_quality.contract.stateless import (
+    STATELESS_REVISION,
+    grade_stateless_conformance,
+    on_stateless_revision,
+)
+from mcp_quality.engines.contract import ContractEngine
+
+from .conftest import make_ctx
+
+_TOOLS = [{"name": "x", "description": "Return x.", "inputSchema": {"type": "object"},
+           "annotations": {"readOnlyHint": True}}]
+
+
+def _codes(findings):
+    return {f.code for f in findings}
+
+
+# -- version detection ---------------------------------------------------------
+
+def test_on_stateless_revision_boundary():
+    assert on_stateless_revision("2026-07-28") is True
+    assert on_stateless_revision("2027-01-01") is True
+    assert on_stateless_revision("2025-11-25") is False
+    assert on_stateless_revision("") is False
+
+
+# -- pure grader ---------------------------------------------------------------
+
+def test_legacy_server_with_no_signals_is_clean():
+    findings, readiness = grade_stateless_conformance("2025-11-25")
+    assert findings == []
+    assert readiness["on_stateless_revision"] is False
+
+
+def test_legacy_missing_discover_is_a_gentle_forward_compat_nudge():
+    findings, _ = grade_stateless_conformance("2025-11-25", discover_ok=False)
+    assert _codes(findings) == {"C10-forward-compat"}  # not a C12 — it's optional pre-2026-07-28
+
+
+def test_stateless_missing_discover_is_a_real_finding():
+    findings, readiness = grade_stateless_conformance(STATELESS_REVISION, discover_ok=False)
+    assert "C12-no-server-discover" in _codes(findings)
+    assert readiness["on_stateless_revision"] is True
+
+
+def test_tools_list_variance_flagged_on_any_revision():
+    legacy, _ = grade_stateless_conformance("2025-11-25", tools_list_stable=False)
+    stateless, _ = grade_stateless_conformance(STATELESS_REVISION, tools_list_stable=False)
+    assert "C12-tools-list-unstable" in _codes(legacy)
+    assert "C12-tools-list-unstable" in _codes(stateless)
+
+
+def test_meta_unenforced_only_matters_on_stateless_revision():
+    legacy, _ = grade_stateless_conformance("2025-11-25", meta_enforced=False)
+    stateless, _ = grade_stateless_conformance(STATELESS_REVISION, meta_enforced=False)
+    assert "C12-meta-unenforced" not in _codes(legacy)
+    assert "C12-meta-unenforced" in _codes(stateless)
+
+
+def test_fully_stateless_conformant_server_is_clean():
+    findings, _ = grade_stateless_conformance(
+        STATELESS_REVISION, discover_ok=True, tools_list_stable=True, meta_enforced=True,
+    )
+    assert findings == []
+
+
+def test_not_measured_signals_produce_no_findings():
+    findings, readiness = grade_stateless_conformance(STATELESS_REVISION)  # all None
+    assert findings == []
+    assert readiness["server_discover"] is None and readiness["tools_list_stable"] is None
+
+
+# -- engine integration (crafted connect records = legacy vs stateless paths) --
+
+async def test_engine_legacy_record_has_no_c12():
+    client = FakeClient(connect_record=ConnectRecord(
+        transport="stdio", protocol_version="2025-11-25", legacy_handshake_ok=True))
+    fs = await ContractEngine().run(make_ctx(_TOOLS, client=client))
+    assert not any(f.code.startswith("C12") for f in fs.findings)
+    assert fs.metrics["stateless_readiness"]["on_stateless_revision"] is False
+
+
+async def test_engine_stateless_record_flags_missing_discover():
+    client = FakeClient(connect_record=ConnectRecord(
+        transport="streamable-http", protocol_version="2026-07-28", stateless_discover_ok=False))
+    fs = await ContractEngine().run(make_ctx(_TOOLS, client=client))
+    assert any(f.code == "C12-no-server-discover" for f in fs.findings)
+    assert fs.metrics["stateless_readiness"]["on_stateless_revision"] is True
+
+
+async def test_engine_unstable_tools_list_flags_and_penalizes():
+    unstable = FakeClient(connect_record=ConnectRecord(
+        transport="stdio", protocol_version="2026-07-28", tools_list_stable=False,
+        stateless_discover_ok=True, meta_enforced=True))
+    stable = FakeClient(connect_record=ConnectRecord(
+        transport="stdio", protocol_version="2026-07-28", tools_list_stable=True,
+        stateless_discover_ok=True, meta_enforced=True))
+    fs_unstable = await ContractEngine().run(make_ctx(_TOOLS, client=unstable))
+    fs_stable = await ContractEngine().run(make_ctx(_TOOLS, client=stable))
+    assert any(f.code == "C12-tools-list-unstable" for f in fs_unstable.findings)
+    assert fs_unstable.score < fs_stable.score  # the bounded penalty bit
+
+
+async def test_engine_static_mode_reports_what_it_can():
+    fs = await ContractEngine().run(make_ctx(_TOOLS, client=None))  # no connect record
+    readiness = fs.metrics["stateless_readiness"]
+    assert readiness["server_discover"] is None  # not measurable offline
+    assert readiness["tools_list_stable"] is None
+    assert not any(f.code.startswith("C12") for f in fs.findings)


### PR DESCRIPTION
Closes #32.

## What

Conformance checks for the **2026-07-28 (stateless) MCP revision** — which drops the `initialize`/`initialized` handshake and session IDs, makes `server/discover` mandatory, requires per-request `_meta`, and forbids `tools/list` from varying per connection. Servers are still catching up, so this is a **version-aware, black-box gate that requires neither path**.

## How it grades (honest by construction)

New pure module `contract/stateless.py` takes the signals the transport managed to observe — each **tri-state** (`True` / `False` / `None` = not measured) — and returns findings + a `stateless_readiness` map:

| Signal | Legacy server | Server *on* 2026-07-28 |
|--------|---------------|------------------------|
| `server/discover` missing | `C10-forward-compat` (LOW, gentle nudge) | `C12-no-server-discover` (MEDIUM) |
| `_meta` not enforced | — (not required yet) | `C12-meta-unenforced` (LOW) |
| `tools/list` varies per connection | `C12-tools-list-unstable` (MEDIUM) | `C12-tools-list-unstable` (MEDIUM) |

Intent scales the severity: a legacy server gets migration guidance, not a failure; a server that *negotiates* the stateless revision but breaks its rules gets a real finding. ISO-date protocol versions compare lexicographically, so `>= "2026-07-28"` is the revision test.

## The one thing we can verify live today

The SDK (`mcp` 1.28.x, `LATEST_PROTOCOL_VERSION = "2025-11-25"`) has no `server/discover` method, so those signals stay `None` = **not measured, never fabricated** (ADR-006). But `tools/list` stability *is* checkable black-box on any server — so `transport.py` opens a **second fresh connection** (`_probe_tools_list_stability`, best-effort → `None` on any failure) and compares surface hashes. Per-connection variance is a genuine defect and carries a **bounded, deterministic −10 penalty**; mere non-adoption of the stateless path is only reported, never scored.

Works in `static` mode too — reports the negotiated version from the surface with all live signals as `not measured`.

## Live output
```json
"stateless_readiness": {
  "protocol_version": "2025-11-25", "on_stateless_revision": false,
  "server_discover": null, "tools_list_stable": true,
  "meta_enforced": null, "supported_versions": []
}
```

## Tests / e2e
- `tests/test_stateless.py` (13 tests): version-boundary detection, the full grader truth-table (legacy-vs-stateless intent, tri-state signals), and engine integration driving **crafted legacy vs stateless connect records** through `ContractEngine` — including the `tools_list_stable=False` penalty and static-mode "reports what it can".
- `tests/test_e2e.py`: a real **two-connection** e2e against `good_server` → `tools_list_stable: true`, no C12.
- Existing C10 tests (SSE, legacy) stay green.
- Full gate: 207 passed, mypy clean, ruff clean.

## Docs
- `docs/DECISIONS.md` D2 updated (was "not yet implemented"); README Contract row.