### PR TITLE
chore(release): 0.3.0 — behavioral conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to mcp-quality are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow [SemVer](https://semver.org/).
 
-## [Unreleased] — v0.3 · behavioral conformance
+## [0.3.0] — 2026-08-30 · behavioral conformance
 
 Doubling down on the checks only a runner can perform: comparing a server's real behavior
 to what its metadata claims. Adds a 6th scored family, an experimental family, and a
@@ -39,7 +39,7 @@ reliability overlay. Rubric bumped to `2026.08.1`.
 - The Scorer excludes zero-weight (experimental) families from the hard gate.
 - `RUBRIC_VERSION` → `2026.08.1`.
 
-## [0.1.0] — unreleased
+## [0.1.0] — 2026-08-28
 
 First public release: the CI quality suite for MCP servers. Grades any MCP server across
 five check families into a single **MCP Quality Score**, gates CI, and prints a badge.
@@ -98,4 +98,5 @@ Also included (planned as the "v0.2" milestone, shipped in this first release):
   (OWASP MCP Top 10 mapping; why the `2026-07-28` stateless `server/discover` path is not
   yet implemented; the offline-token estimate).
 
+[0.3.0]: https://github.com/swarmproof/mcp-probe/releases/tag/v0.3.0
 [0.1.0]: https://github.com/swarmproof/mcp-probe/releases/tag/v0.1.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,8 +46,8 @@ handoff seed · a registry scoring API (`mcp-quality serve`) · read-only by def
 
 ## 📍 Where we are now
 
-- **Live on PyPI** (`mcp-quality 0.1.0`), published via trusted publishing. The v0.3
-  behavioral-conformance work is merged on `main`, awaiting a `0.3.0` cut.
+- **Live on PyPI** (`mcp-quality 0.3.0`), published via trusted publishing — the v0.3
+  behavioral-conformance milestone.
 - **Six scored families** (Contract · Cost · Legibility · Performance · Security-lite ·
   Safety-Contract) plus an **experimental** spec-surface family, all behind one rubric.
 - **Green CI** across Python 3.11/3.12 — 219 tests (unit · component · integration · E2E
@@ -57,7 +57,7 @@ handoff seed · a registry scoring API (`mcp-quality serve`) · read-only by def
 
 ---
 
-## ✅ Shipped — v0.3: behavioral conformance (on `main`)
+## ✅ Shipped — v0.3: behavioral conformance (`0.3.0`)
 
 The checks only a runner can perform: comparing a server's real behavior to its declared
 contract. All merged. ([milestone](https://github.com/swarmproof/mcp-probe/milestone/2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-quality"
-version = "0.1.0"
+version = "0.3.0"
 description = "The CI quality suite for MCP servers — lint, contract-test, benchmark, and load-test your MCP server before you ship it."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/mcp_quality/__init__.py
+++ b/src/mcp_quality/__init__.py
@@ -7,7 +7,7 @@ See ``docs/ARCHITECTURE.md`` for the system design and ``docs/PRD.md`` for the
 numbered requirements this package implements.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"
 
 # The scoring rubric is versioned so historical scores stay comparable (NFR-7, ADR-008).
 # Bump on any change to weights, grade bands, or sub-score composition.


### PR DESCRIPTION
Release prep for **`mcp-quality 0.3.0`**, the behavioral-conformance milestone (issues #25–33, all merged and e2e-covered).

- `pyproject.toml` + `__version__`: `0.1.0` → **`0.3.0`**.
- CHANGELOG: `[Unreleased] — v0.3` → **`[0.3.0] — 2026-08-30`**; dated the `0.1.0` entry (it's live on PyPI); added the `[0.3.0]` release link.
- ROADMAP: reflects `0.3.0` as the current PyPI release.

Build verified locally — `python -m build` produces `mcp_quality-0.3.0` (wheel + sdist), import reports `0.3.0`.

**After merge:** publishing a GitHub Release tagged `v0.3.0` triggers `release.yml` (Trusted Publishing / OIDC) to build and upload to PyPI. No new checks or code — release bookkeeping only.